### PR TITLE
Tutorial state transition validations

### DIFF
--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext
 from rest_framework import serializers
 
 from apps.common.serializers import UserResourceSerializer
+from apps.tutorial.models import Tutorial
 from project_types.store import get_project_property
 from utils.common import clean_up_none_keys
 from utils.graphql.drf import handle_pydantic_validation_error
@@ -73,20 +74,38 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
             "tutorial",
         )
 
-    def validate_status(self, new_status: Project.Status | int | None):
+    def validate_status(self, new_status: Project.Status | int) -> Project.Status:
         assert self.instance is not None
 
-        if new_status is None:
-            return None
         if isinstance(new_status, int):
             new_status = Project.Status(new_status)
 
-        if (self.instance.status_enum, new_status) not in VALID_PROJECT_STATUS_TRANSITIONS:
+        if (
+            self.instance.status_enum != new_status
+            and (self.instance.status_enum, new_status) not in VALID_PROJECT_STATUS_TRANSITIONS
+        ):
             raise serializers.ValidationError(
                 gettext("Project status cannot be changed from %s to %s")
-                % (self.instance.status_enum.label, new_status.label),
+                % (
+                    self.instance.status_enum.label,
+                    new_status.label,
+                ),
             )
         return new_status
+
+    def validate_tutorial(self, tutorial: Tutorial | None) -> Tutorial | None:
+        assert self.instance is not None
+        current_tutorial = self.instance.tutorial
+
+        if tutorial and tutorial != current_tutorial and tutorial.status == Tutorial.Status.ARCHIVED:
+            raise serializers.ValidationError(gettext("Cannot assign archived tutorial to the project."))
+
+        # NOTE: If tutorial is provided, project attached to the tutorial should match the current project type
+        if tutorial and tutorial.project and tutorial.project.project_type != self.instance.project_type:
+            raise serializers.ValidationError(
+                {"tutorial": gettext("Tutorial project type does not match the project type.")},
+            )
+        return tutorial
 
     def validate_image(self, new_image: ProjectAsset | None):
         assert self.instance is not None
@@ -245,12 +264,22 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
 
     def _validate_tutorial(self, attrs: dict[str, typing.Any]):
         assert self.instance is not None
-        tutorial = attrs.get("tutorial") or self.instance.tutorial
-        # FIXME: Add validation that tutorial and project types must match
+        new_tutorial = attrs.get("tutorial")
+        current_tutorial = self.instance.tutorial
+        tutorial = new_tutorial or current_tutorial
 
         if tutorial is None and attrs.get("status") == Project.Status.PUBLISHED:
             raise serializers.ValidationError(
                 {"tutorial": gettext("Tutorial is required before publishing a project.")},
+            )
+
+        if new_tutorial and new_tutorial != current_tutorial and new_tutorial.status == Tutorial.Status.ARCHIVED:
+            raise serializers.ValidationError(gettext("Cannot assign archived tutorial to the project."))
+
+        # NOTE: If tutorial is provided, project attached to the tutorial should match the current project type
+        if tutorial and tutorial.project and tutorial.project.project_type != self.instance.project_type:
+            raise serializers.ValidationError(
+                {"tutorial": gettext("Tutorial project type does not match the project type.")},
             )
 
     @typing.override

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -16,6 +16,7 @@ from apps.project.models import (
 )
 from apps.project.tasks import process_project_task
 from apps.tutorial.factories import TutorialFactory
+from apps.tutorial.models import Tutorial
 from apps.user.factories import UserFactory
 from main.tests import TestCase
 from project_types.tile_map_service.compare import project as compare_project
@@ -402,13 +403,24 @@ class TestProjectMutation(TestCase):
         )
 
     def _update_project_mutation(self, pk: str, project_data: dict, **kwargs):
-        return update_project_query(
-            query_check_func=self.query_check,
-            query=Mutation.UPDATE_PROJECT,
-            pk=pk,
-            project_data=project_data,
-            **kwargs,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            return update_project_query(
+                query_check_func=self.query_check,
+                query=Mutation.UPDATE_PROJECT,
+                pk=pk,
+                project_data=project_data,
+                **kwargs,
+            )
+
+    def _update_processed_project_mutation(self, pk: str, project_data: dict, **kwargs):
+        with self.captureOnCommitCallbacks(execute=True):
+            return update_project_query(
+                query_check_func=self.query_check,
+                query=Mutation.UPDATE_PROCESSED_PROJECT,
+                pk=pk,
+                project_data=project_data,
+                **kwargs,
+            )
 
     def test_project_create(self):
         project_data = {
@@ -468,7 +480,8 @@ class TestProjectMutation(TestCase):
             ),
         ), content
 
-    def test_project_update(self):
+    @patch("apps.project.serializers.process_project_task.delay")
+    def test_project_update(self, mock_requests):
         proj = ProjectFactory.create(
             **self.user_resource_kwargs,
             project_type=ProjectTypeEnum.FIND,
@@ -671,6 +684,49 @@ class TestProjectMutation(TestCase):
         content = self._update_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProject"]["errors"] is None
 
+        mock_requests.assert_called_once()
+        mock_requests.assert_has_calls([call(latest_project.pk)])
+
+        process_project_task(latest_project.pk)
+
+        latest_project.refresh_from_db()
+
+        assert latest_project.status == Project.Status.READY
+
+        # Attaching Tutorial to Project
+        # fails as tutorial is archived
+        archived_tutorial = TutorialFactory.create(
+            **self.user_resource_kwargs,
+            project=latest_project,
+            status=Tutorial.Status.ARCHIVED,
+        )
+        project_data = {
+            "clientId": proj.client_id,
+            "status": self.genum(Project.Status.PUBLISHED),
+            "tutorial": self.gID(archived_tutorial.pk),
+        }
+        content = self._update_project_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProject"]["errors"] is not None
+
+        # Unarchiving Tutorial
+        archived_tutorial.status = Tutorial.Status.PUBLISHED
+        archived_tutorial.save(update_fields=["status"])
+
+        content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProcessedProject"]["errors"] is None, content
+
+        # Archiving tutorial
+        # Test Pass as archiving tutorial does not affect project on published projects
+        archived_tutorial.status = Tutorial.Status.ARCHIVED
+        archived_tutorial.save(update_fields=["status"])
+
+        project_data = {
+            "clientId": proj.client_id,
+            "tutorial": self.gID(archived_tutorial.pk),
+        }
+        content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProcessedProject"]["errors"] is None, content
+
 
 class TestProjectTypeMutation(TestCase):
     @typing.override
@@ -687,7 +743,7 @@ class TestProjectTypeMutation(TestCase):
 
         cls.compare_project = ProjectFactory.create(
             **cls.user_resource_kwargs,
-            project_type=ProjectTypeEnum.FIND,
+            project_type=ProjectTypeEnum.COMPARE,
             requesting_organization=cls.organization,
             project_type_specifics=None,
         )

--- a/apps/tutorial/models.py
+++ b/apps/tutorial/models.py
@@ -46,6 +46,8 @@ class Tutorial(UserResource):
     # FIXME(tnagorra): We might need to skip the indexing
     old_id = models.CharField(max_length=30, db_index=True, null=True)
 
+    Status = TutorialStatusEnum
+
     # FIXME(tnagorra): We might need to rename this field
     project = models.ForeignKey(
         Project,
@@ -64,6 +66,10 @@ class Tutorial(UserResource):
     project_id: int
     scenarios: RelatedManager["TutorialScenarioPage"]
     information_pages: RelatedManager["TutorialInformationPage"]
+
+    @property
+    def status_enum(self) -> TutorialStatusEnum:
+        return TutorialStatusEnum(self.status)
 
 
 class TutorialScenarioIconEnum(models.IntegerChoices):

--- a/apps/tutorial/serializers.py
+++ b/apps/tutorial/serializers.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext
 from rest_framework import serializers
 
 from apps.common.serializers import DrfContextType, UserResourceSerializer
-from apps.project.models import ProjectTypeEnum
+from apps.project.models import Project, ProjectTypeEnum
 from project_types.store import get_tutorial_task_property
 from utils.common import clean_up_none_keys
 from utils.graphql.drf import handle_pydantic_validation_error
@@ -277,6 +277,15 @@ class TutorialInformationPageSerializer(
         return page
 
 
+VALID_TUTORIAL_STATUS_TRANSITIONS: set[tuple[Tutorial.Status, Tutorial.Status]] = set(
+    [
+        (Tutorial.Status.DRAFT, Tutorial.Status.PUBLISHED),
+        (Tutorial.Status.DRAFT, Tutorial.Status.DISCARDED),
+        (Tutorial.Status.PUBLISHED, Tutorial.Status.ARCHIVED),
+    ],
+)
+
+
 class TutorialSerializer(UserResourceSerializer[Tutorial]):
     scenarios = TutorialScenarioPageSerializer(many=True)
     information_pages = TutorialInformationPageSerializer(many=True)
@@ -290,6 +299,34 @@ class TutorialSerializer(UserResourceSerializer[Tutorial]):
             "information_pages",
             "scenarios",
         )
+
+    def validate_status(self, new_status: Tutorial.Status | int) -> Tutorial.Status:
+        if not self.instance and new_status:
+            raise serializers.ValidationError(
+                gettext("Cannot set status for a new tutorial. Status can only be set for existing tutorials."),
+            )
+
+        if isinstance(new_status, int):
+            new_status = Tutorial.Status(new_status)
+
+        if (
+            self.instance
+            and self.instance.status_enum != new_status
+            and (self.instance.status_enum, new_status) not in VALID_TUTORIAL_STATUS_TRANSITIONS
+        ):
+            raise serializers.ValidationError(
+                gettext("Tutorial status cannot be changed from %s to %s")
+                % (Tutorial.Status(self.instance.status).label, new_status.label),
+            )
+        return new_status
+
+    def validate_project(self, project: Project) -> Project:
+        if self.instance and self.instance.project and self.instance.project.project_type != project.project_type:
+            raise serializers.ValidationError(
+                gettext("Existing tutorial project type '%s' does not match new project type '%s'")
+                % (Project.Type(self.instance.project.project_type).label, Project.Type(project.project_type).label),
+            )
+        return project
 
     @typing.override
     def create(self, validated_data: dict[typing.Any, typing.Any]):
@@ -325,8 +362,8 @@ class TutorialSerializer(UserResourceSerializer[Tutorial]):
 
     @typing.override
     def update(self, instance: Tutorial, validated_data: dict[typing.Any, typing.Any]):
-        scenarios_data = self.initial_data["scenarios"] or []
-        information_pages_data = self.initial_data["information_pages"] or []
+        scenarios_data = self.initial_data.get("scenarios") or []
+        information_pages_data = self.initial_data.get("information_pages") or []
         validated_data.pop("scenarios", None)
         validated_data.pop("information_pages", None)
         tutorial = super().update(instance, validated_data)

--- a/apps/tutorial/tests/mutation_test.py
+++ b/apps/tutorial/tests/mutation_test.py
@@ -7,10 +7,12 @@ from apps.project.factories import OrganizationFactory, ProjectFactory
 from apps.project.models import (
     ProjectTypeEnum,
 )
+from apps.tutorial.factories import TutorialFactory
 from apps.tutorial.models import (
     Tutorial,
     TutorialStatusEnum,
 )
+from apps.tutorial.serializers import VALID_TUTORIAL_STATUS_TRANSITIONS
 from apps.user.factories import UserFactory
 from main.tests import TestCase
 from utils.common import format_object_keys, to_camel_case
@@ -578,3 +580,68 @@ class TestTutorialMutation(TestCase):
                 ],
             ),
         ), content
+
+        # Test the tutorial with different project_type
+        compare_project = ProjectFactory.create(
+            **self.user_resource_kwargs,
+            project_type=ProjectTypeEnum.COMPARE,
+            requesting_organization=self.organization,
+            name="Compare Project 101",
+            look_for="",
+            additional_info_url="https://hi-there/about.html",
+            description="The new **project** from hi-there.",
+            project_type_specifics=None,
+        )
+        tutorial_data["project"] = self.gID(compare_project.pk)
+        content = self._update_tutorial_mutation(str(latest_tutorial.pk), tutorial_data)
+        assert content["data"]["updateTutorial"]["errors"] is not None, content
+
+    def test_tutorial_state_transitions(self):
+        # Create a draft tutorial
+        tutorial = TutorialFactory.create(
+            client_id=str(ULID()),
+            name="Status Tutorial",
+            project=self.project,
+            created_by=self.user,
+            modified_by=self.user,
+            status=TutorialStatusEnum.DRAFT,
+        )
+
+        # Checking with authenticated user
+        self.force_login(self.user)
+        for status, new_status in VALID_TUTORIAL_STATUS_TRANSITIONS:
+            tutorial.status = status
+            tutorial.save(update_fields=["status"])
+            data = {
+                "clientId": tutorial.client_id,
+                "project": self.gID(tutorial.project_id),
+                "status": self.genum(new_status),
+            }
+            response = self._update_tutorial_mutation(str(tutorial.pk), data)
+
+            resp_data = response["data"]["updateTutorial"]
+            assert resp_data["errors"] is None, response
+            tutorial.refresh_from_db()
+            assert tutorial.status == new_status
+
+        invalid_transitions = [
+            (TutorialStatusEnum.PUBLISHED, TutorialStatusEnum.DRAFT),
+            (TutorialStatusEnum.ARCHIVED, TutorialStatusEnum.PUBLISHED),
+            (TutorialStatusEnum.DRAFT, TutorialStatusEnum.ARCHIVED),
+        ]
+
+        for old_status, new_status in invalid_transitions:
+            tutorial.status = old_status
+            tutorial.save(update_fields=["status"])
+            data = {
+                "clientId": tutorial.client_id,
+                "project": self.gID(tutorial.project_id),
+                "status": self.genum(new_status),
+            }
+            response = self._update_tutorial_mutation(str(tutorial.pk), data)
+
+            resp_data = response["data"]["updateTutorial"]
+            assert resp_data["errors"] is not None, response
+            assert "Tutorial status cannot be changed" in resp_data["errors"][0]["messages"], response
+            tutorial.refresh_from_db()
+            assert tutorial.status == old_status


### PR DESCRIPTION
Tutorial state transition and update validation checks

## Addresses
- Validation checks on tutorials and projects

## Changes
- Add validation checks on projects regarding archieved tutorials
- Add validations checks on tutorial for the state transtitions
- Fix minor issues
- Add test cases for the status checks on tutorials

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
