### PR TITLE
feat: add config to enable/disable graphiql

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ x-server: &base_server_setup
     ENABLE_DEBUG_TOOLBAR: ${ENABLE_DEBUG_TOOLBAR:-true}
     APP_ENVIRONMENT: ${APP_ENVIRONMENT:-DEV}
     SECRET_KEY: ${SECRET_KEY:?error}
+    ENABLE_STRAWBERRY_GRAPHIQL: ${ENABLE_STRAWBERRY_GRAPHIQL:-true}
     # Domain configs
     APP_DOMAIN: ${APP_DOMAIN:-http://localhost:8000}
     FRONTEND_DOMAIN: ${FRONTEND_DOMAIN:-http://localhost:3000}  # NOTE: Not used right now

--- a/main/settings.py
+++ b/main/settings.py
@@ -25,6 +25,7 @@ env = environ.Env(
     APP_TYPE=str,  # WEB, WORKER, WORKER-BEAT
     APP_RELEASE=(str, None),  # As fallback we will try to use .git/HEAD
     APP_LOG_LEVEL=(str, "INFO"),
+    ENABLE_STRAWBERRY_GRAPHIQL=(bool, False),
     # Domain configs
     APP_DOMAIN=str,  # Eg: https://api.example.org
     FRONTEND_DOMAIN=str,  # Eg: https://web.example.org
@@ -427,6 +428,7 @@ if SENTRY_ENABLED:
     SENTRY_CONFIG.init_sentry()
 
 # Strawberry
+ENABLE_STRAWBERRY_GRAPHIQL = env("ENABLE_STRAWBERRY_GRAPHIQL")
 STRAWBERRY_DJANGO = {
     "FIELD_DESCRIPTION_FROM_HELP_TEXT": True,
     "TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING": True,

--- a/main/urls.py
+++ b/main/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
     path("rest/docs-swagger/", SpectacularSwaggerView.as_view(url_name="rest-docs"), name="rest-swagger"),
 ]
 
-if settings.DEBUG:
+if settings.ENABLE_STRAWBERRY_GRAPHIQL:
     urlpatterns.extend(
         [
             path(
@@ -57,6 +57,7 @@ if settings.DEBUG:
         ],
     )
 
+if settings.DEBUG:
     # Static and media file URLs
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Addresses
- Enable graphiql in alpha environment

## Changes

* Add environment config to enable graphiql
* Enable graphiql in development by default using docker-compose

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
