### PR TITLE
Add contributor users inline in team page admin panel

### DIFF
--- a/apps/contributor/admin.py
+++ b/apps/contributor/admin.py
@@ -20,8 +20,16 @@ class ContributorUserGroupAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
     pass
 
 
+class ContributorUserInline(admin.TabularInline):
+    model = ContributorUser
+    extra = 1
+    fields = ("user_id", "username", "created_at", "modified_at")
+    can_delete = False
+
+
 @admin.register(ContributorTeam)
 class ContributorTeamAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+    inlines = [ContributorUserInline]
     list_display = (
         "name",
         "is_archived",


### PR DESCRIPTION
Addresses
- Add Contributor users list to the team page admin panel

NOTE: **Mention related users here if any.**

## Changes

* Detailed list or prose of changes
* Breaking changes
* Changes to configurations

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
