### PR TITLE
Add validation checks for the organization on project

### DIFF
--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -40,6 +40,11 @@ VALID_PROCESSED_PROJECT_STATUS_TRANSITIONS = set(
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
 class ProjectCreateSerializer(UserResourceSerializer[Project]):
+    requesting_organization = serializers.PrimaryKeyRelatedField(
+        queryset=Organization.objects.filter(is_archived=False),
+        required=True,
+    )
+
     class Meta:  # type: ignore[reportIncompatibleVariableOverride]
         model = Project
         fields = (
@@ -56,6 +61,11 @@ class ProjectCreateSerializer(UserResourceSerializer[Project]):
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
 class ProjectUpdateSerializer(UserResourceSerializer[Project]):
+    requesting_organization = serializers.PrimaryKeyRelatedField(
+        queryset=Organization.objects.filter(is_archived=False),
+        required=True,
+    )
+
     class Meta:  # type: ignore[reportIncompatibleVariableOverride]
         model = Project
         fields = (
@@ -210,6 +220,11 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
 class ProcessedProjectSerializer(UserResourceSerializer[Project]):
+    requesting_organization = serializers.PrimaryKeyRelatedField(
+        queryset=Organization.objects.filter(is_archived=False),
+        required=True,
+    )
+
     class Meta:  # type: ignore[reportIncompatibleVariableOverride]
         model = Project
         fields = (

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -509,6 +509,16 @@ class TestProjectMutation(TestCase):
             ),
         ), content
 
+        # Creating project with archived Organization
+        # Fails as organization is archived
+        archived_organization = OrganizationFactory.create(
+            **self.user_resource_kwargs,
+            is_archived=True,
+        )
+        project_data["requestingOrganization"] = archived_organization.pk
+        content = self._create_project_mutation(project_data)
+        assert content["data"]["createProject"]["errors"] is not None, content
+
     @patch("apps.project.serializers.process_project_task.delay")
     def test_project_update(self, mock_requests):
         proj = ProjectFactory.create(
@@ -578,6 +588,16 @@ class TestProjectMutation(TestCase):
                 tutorial=None,
             ),
         ), content
+
+        # Updating project with archived Organization
+        # Fails as organization is archived
+        archived_organization = OrganizationFactory.create(
+            **self.user_resource_kwargs,
+            is_archived=True,
+        )
+        project_data["requestingOrganization"] = archived_organization.pk
+        content = self._update_project_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProject"]["errors"] is not None, content
 
         # Updating Project: Status change
         # fails as project specifics is required when changing status to "marked as ready"
@@ -721,6 +741,16 @@ class TestProjectMutation(TestCase):
         latest_project.refresh_from_db()
 
         assert latest_project.status == Project.Status.READY
+
+        # Updating processed project with archived Organization
+        # Fails as organization is archived
+        archived_organization = OrganizationFactory.create(
+            **self.user_resource_kwargs,
+            is_archived=True,
+        )
+        project_data["requestingOrganization"] = archived_organization.pk
+        content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProcessedProject"]["errors"] is not None, content
 
         # Attaching Tutorial to Project
         # fails as tutorial is archived


### PR DESCRIPTION
Addresses
- Add validation checks on project create, update, processed project serializers

## Changes

* Detailed list or prose of changes
* Breaking changes
* Changes to configurations

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
