### PR TITLE
Add validation check for team on project

### DIFF
--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext
 from rest_framework import serializers
 
 from apps.common.serializers import ArchivableResourceSerializer, UserResourceSerializer
+from apps.contributor.models import ContributorTeam
 from apps.project.firebase import push_organization_to_firebase
 from apps.tutorial.models import Tutorial
 from project_types.store import get_project_property
@@ -61,6 +62,13 @@ class ProjectCreateSerializer(UserResourceSerializer[Project]):
             "team",
         )
 
+    def validate_team(self, team: ContributorTeam | None) -> ContributorTeam | None:
+        if team and team.is_archived:
+            raise serializers.ValidationError(
+                gettext("Cannot use archived team on a project."),
+            )
+        return team
+
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
 class ProjectUpdateSerializer(UserResourceSerializer[Project]):
@@ -89,6 +97,13 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
             "tutorial",
             "team",
         )
+
+    def validate_team(self, team: ContributorTeam | None) -> ContributorTeam | None:
+        if team and team.is_archived:
+            raise serializers.ValidationError(
+                gettext("Cannot use archived team on a project."),
+            )
+        return team
 
     def validate_status(self, new_status: Project.Status | int) -> Project.Status:
         assert self.instance is not None, "Project does not exist."
@@ -245,6 +260,13 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
             "tutorial",
             "team",
         )
+
+    def validate_team(self, team: ContributorTeam | None) -> ContributorTeam | None:
+        if team and team.is_archived:
+            raise serializers.ValidationError(
+                gettext("Cannot use archived team on a project."),
+            )
+        return team
 
     def validate_status(self, new_status: Project.Status | int):
         assert self.instance is not None, "Project does not exist."

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.files.temp import NamedTemporaryFile
 from ulid import ULID
 
+from apps.contributor.factories import ContributorTeamFactory
 from apps.project.factories import OrganizationFactory, ProjectFactory
 from apps.project.models import (
     Project,
@@ -496,6 +497,16 @@ class TestProjectMutation(TestCase):
         response = content["data"]["createProject"]
         assert response["errors"] is not None, content
 
+        # Creating project with archived team
+        # Fails as team is archived
+        archived_team = ContributorTeamFactory.create(
+            **self.user_resource_kwargs,
+            is_archived=True,
+        )
+        project_data["team"] = archived_team.pk
+        response = content["data"]["createProject"]
+        assert response["errors"] is not None, content
+
         latest_project = Project.objects.get(pk=resp_data["result"]["id"])
         assert latest_project.created_by_id == self.user.pk
         assert latest_project.modified_by_id == self.user.pk
@@ -612,6 +623,16 @@ class TestProjectMutation(TestCase):
                 tutorial=None,
             ),
         ), content
+
+        # Updating project with archived team
+        # fails as team is archived
+        archived_team = ContributorTeamFactory.create(
+            **self.user_resource_kwargs,
+            is_archived=True,
+        )
+        project_data["team"] = archived_team.pk
+        content = self._update_project_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProject"]["errors"] is not None, content
 
         # Updating project with archived Organization
         # Fails as organization is archived
@@ -818,6 +839,16 @@ class TestProjectMutation(TestCase):
         content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProcessedProject"]["errors"] is None, content
         assert content["data"]["updateProcessedProject"]["result"]["status"] == self.genum(ProjectStatusEnum.ARCHIVED)
+
+        # Updating project with archived team
+        # fails as team is archived
+        archived_team = ContributorTeamFactory.create(
+            **self.user_resource_kwargs,
+            is_archived=True,
+        )
+        project_data["team"] = archived_team.pk
+        content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProcessedProject"]["errors"] is not None, content
 
 
 class TestProjectTypeMutation(TestCase):


### PR DESCRIPTION
Addresses
- Add validation checks on project for team as archived teams cannot be attached to the project.

NOTE: **Mention related users here if any.**

## Changes
- Add team checks on project for achiving team
- Add test cases on project for achiving team on projects

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
