### PR TITLE
Add validation checks for geojson asset

### DIFF
--- a/apps/common/serializers.py
+++ b/apps/common/serializers.py
@@ -13,7 +13,7 @@ from rest_framework import serializers
 from apps.common.models import ArchivableResource, UserResource
 from apps.project.models import CommonAsset
 from apps.user.models import User
-from utils.common import validate_ulid
+from utils.common import validate_geojson_file, validate_ulid
 
 from .types import FirebaseDecodedIdToken
 
@@ -202,6 +202,9 @@ class CommonAssetSerializer(serializers.ModelSerializer[CommonAsset]):
             raise serializers.ValidationError(
                 gettext("File mimetype does not match the provided mimetype: %s") % mimetype,
             )
+
+        if attrs["mimetype"] == CommonAsset.Mimetype.GEOJSON:
+            validate_geojson_file(file_content)
 
         attrs["mimetype"] = CommonAsset.Mimetype.get_mimetype_by_label(mimetype)
         attrs["file_size"] = file_size

--- a/utils/common.py
+++ b/utils/common.py
@@ -7,8 +7,10 @@ import re
 import typing
 
 from django.core.exceptions import ValidationError
+from django.core.files.base import ContentFile
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.translation import gettext
+from geojson_pydantic import FeatureCollection
 from ulid import ULID
 
 
@@ -115,3 +117,26 @@ def parse_b64gzjson_to_dict(text: str) -> dict[str, typing.Any]:
     with gzip.GzipFile(fileobj=io.BytesIO(gzipped_bytes)) as f:
         json_bytes = f.read()
         return json.loads(json_bytes.decode("utf-8"))
+
+
+def validate_geojson_file(file: ContentFile) -> None:
+    """
+    Validates if the given file contains a valid GeoJSON FeatureCollection.
+
+    Args:
+        file: File object
+
+    Raises:
+        ValidationError: If the file is not a valid JSON or does not conform to GeoJSON standards.
+        ValueError: If the GeoJSON doesn't meet expected structure.
+    """
+
+    try:
+        geojson_data = json.load(file)
+    except json.JSONDecodeError as e:
+        raise ValidationError("Invalid JSON format in the file.") from e
+
+    feature_collection = FeatureCollection(**geojson_data)
+
+    if not feature_collection.features:
+        raise ValidationError("GeoJSON 'features' list cannot be empty.")


### PR DESCRIPTION
Addresses
- validation checks for the geojson asset file

## Changes
- Add new validation check for geojson
- Update validation check for geojson asset file in serializer

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
