### PR TITLE
Send NULL to firebase to enable clearing data

### DIFF
--- a/.github/gh-docker-compose.yaml
+++ b/.github/gh-docker-compose.yaml
@@ -1,7 +1,9 @@
 services:
   firebase-test:
-    image: ghcr.io/mapswipe/mapswipe-firebase:0.0.1-dev
+    image: ghcr.io/mapswipe/mapswipe-firebase:0.2.0-dev
     build: !reset null
+    environment:
+      CI: "true"
 
   test:
     image: $DOCKER_IMAGE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,13 @@ jobs:
           echo "tagged_image=${IMAGE_NAME}:${TAG}" >> $GITHUB_OUTPUT
           echo "::notice::Tagged docker image: ${IMAGE_NAME}:${TAG}"
 
+      - name: Start firebase emulator (in background)
+        env:
+          DOCKER_IMAGE: ${{ steps.prep.outputs.tagged_image }}
+        run: |
+          # TODO: Also move docker pull process in the background
+          docker compose up -d firebase-test
+
       - name: 🐳 Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -124,7 +131,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Start app resources
-        timeout-minutes: 2
+        timeout-minutes: 1
         env:
           DOCKER_IMAGE: ${{ steps.prep.outputs.tagged_image }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,14 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Start app resources
-        timeout-minutes: 1
+        timeout-minutes: 2
         env:
           DOCKER_IMAGE: ${{ steps.prep.outputs.tagged_image }}
         run: |
-          docker compose run --rm test ./manage.py wait_for_resources --all || {
-            echo 'Failed to wait for the resources';
-            exit 1;
+          timeout 60s docker compose run --rm test ./manage.py wait_for_resources --all || {
+            echo 'Failed to wait for resources'
+            docker compose logs
+            exit 1
           }
 
       - name: Validate if there are no pending django migrations.

--- a/apps/common/firebase.py
+++ b/apps/common/firebase.py
@@ -3,6 +3,7 @@ import logging
 import typing
 
 from firebase_admin.db import Reference as FbReference
+from pydantic import BaseModel, ConfigDict
 
 from apps.common.models import FirebasePushResource, FirebasePushStatusEnum
 from main.celery import app
@@ -14,8 +15,10 @@ logger = logging.getLogger(__name__)
 class InvalidObjectPushException(Exception): ...
 
 
-class FirebasePush[T: FirebasePushResource](abc.ABC):
-    model: type[T]
+# FIXME(tnagorra): Add inheritance_checks for model and firebase_model
+class FirebasePush[T: FirebasePushResource, K: BaseModel](abc.ABC):
+    model_class: type[T]
+    firebase_model_class: type[K]
 
     def __init__(
         self,
@@ -23,32 +26,63 @@ class FirebasePush[T: FirebasePushResource](abc.ABC):
     ):
         self.obj_id = obj_id
 
+    @classmethod
+    def _inheritance_checks(cls):
+        # FIXME(tnagorra): Find a better way to skip for base classes
+        if cls.__name__ == "FirebasePush":
+            # Skip check for the abstract class
+            return
+
+        missing_fields = []
+        for attr_name in [
+            "model_class",
+            "firebase_model_class",
+        ]:
+            if getattr(cls, attr_name, None) is None:
+                missing_fields.append(attr_name)
+
+        if missing_fields:
+            raise NotImplementedError(f"Please define {','.join(missing_fields)} for {cls}")
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._inheritance_checks()
+
     @abc.abstractmethod
     def handle_new_object_on_firebase(self, model_obj: T, fb_reference: FbReference): ...
 
     @abc.abstractmethod
-    def handle_object_update_on_firebase(self, model_obj: T, fb_reference: FbReference): ...
+    def handle_object_update_on_firebase(self, model_obj: T, fb_obj: K, fb_reference: FbReference): ...
 
     @abc.abstractmethod
     def get_firebase_path(self, firebase_id: str, model: type[T]) -> str: ...
 
     def push(self) -> None:
-        model_obj = self.model.objects.get(id=self.obj_id)
+        model_obj = self.model_class.objects.get(id=self.obj_id)
+
+        # FIXME(tnagorra): The following fails because set firebase_push_status is not set on create/update
+        # if model_obj.firebase_push_status_enum != FirebasePushStatusEnum.PENDING:
+        #     logger.warning(
+        #         "Firebase push error: push is not required for %s",
+        #         model_obj._meta.label,
+        #         extra={"id": model_obj.pk},
+        #     )
+        #     return
 
         model_obj.update_firebase_push_status(FirebasePushStatusEnum.PROCESSING)
 
         try:
             model_ref = Config.FIREBASE_HELPER.ref(
-                self.get_firebase_path(model_obj.firebase_id, self.model),
+                self.get_firebase_path(model_obj.firebase_id, self.model_class),
             )
             fb_model: typing.Any = model_ref.get()
 
             if not model_obj.firebase_last_pushed:
                 if fb_model is not None:
                     logger.error(
-                        "Firebase creation error: existing %s found",
+                        "Firebase create error: %s already exists in Firebase",
                         model_obj._meta.label,
-                        extra={"model_obj_id": model_obj.pk},
+                        extra={"id": model_obj.pk},
                     )
                     raise InvalidObjectPushException
                 self.handle_new_object_on_firebase(model_obj, model_ref)
@@ -57,17 +91,24 @@ class FirebasePush[T: FirebasePushResource](abc.ABC):
                     logger.error(
                         "Firebase update error: missing %s in Firebase",
                         model_obj._meta.label,
-                        extra={"model_obj_id": model_obj.pk},
+                        extra={"id": model_obj.pk},
                     )
                     raise InvalidObjectPushException
-                self.handle_object_update_on_firebase(model_obj, model_ref)
 
+                class RelaxedModel(self.firebase_model_class):
+                    model_config = ConfigDict(extra="ignore")
+
+                # NOTE: we want to ignore extra fields from firebase
+                valid_fb_model = RelaxedModel.model_validate(obj=fb_model)
+                valid_fb_model = self.firebase_model_class.model_validate(valid_fb_model)
+
+                self.handle_object_update_on_firebase(model_obj, valid_fb_model, model_ref)
         except InvalidObjectPushException:
             model_obj.update_firebase_push_status(FirebasePushStatusEnum.FAILED)
         except Exception:
             logger.error(
-                "Unexpected error while pushing to Firebase",
-                extra={"model_obj_id": model_obj.pk},
+                "Firebase push error: Unexpected error occurred",
+                extra={"id": model_obj.pk},
                 exc_info=True,
             )
             model_obj.update_firebase_push_status(FirebasePushStatusEnum.FAILED)

--- a/apps/common/models.py
+++ b/apps/common/models.py
@@ -131,6 +131,8 @@ class FirebasePushResource(Model):
         help_text=gettext_lazy("The latest time when resource was pushed to firebase"),
     )
 
+    # FIXME(tnagorra): Override create and update to set FirebasePushStatusEnum.PENDING
+
     @property
     def firebase_push_status_enum(self):
         if self.firebase_push_status:

--- a/apps/contributor/firebase.py
+++ b/apps/contributor/firebase.py
@@ -3,6 +3,7 @@ import typing
 
 from celery import shared_task
 from firebase_admin.db import Reference as FbReference
+from pyfirebase_mapswipe import extended_models as firebase_ext_models
 from pyfirebase_mapswipe import models as firebase_models
 from pyfirebase_mapswipe import utils as firebase_utils
 
@@ -14,9 +15,9 @@ from main.config import Config
 logger = logging.getLogger(__name__)
 
 
-class FirebaseContributorTeam(FirebasePush[ContributorTeam]):
-    model_obj: ContributorTeam
-    model = ContributorTeam
+class FirebaseContributorTeam(FirebasePush[ContributorTeam, firebase_models.FbTeam]):
+    model_class = ContributorTeam
+    firebase_model_class = firebase_models.FbTeam
 
     @typing.override
     def handle_new_object_on_firebase(self, model_obj: ContributorTeam, fb_reference: FbReference):
@@ -31,7 +32,12 @@ class FirebaseContributorTeam(FirebasePush[ContributorTeam]):
         )
 
     @typing.override
-    def handle_object_update_on_firebase(self, model_obj: ContributorTeam, fb_reference: FbReference):
+    def handle_object_update_on_firebase(
+        self,
+        model_obj: ContributorTeam,
+        fb_obj: firebase_models.FbTeam,
+        fb_reference: FbReference,
+    ):
         fb_reference.update(
             value=firebase_utils.serialize(
                 firebase_models.FbTeam(
@@ -53,9 +59,9 @@ class FirebaseContributorTeam(FirebasePush[ContributorTeam]):
         FirebaseContributorTeam(obj_id).push()
 
 
-class FirebaseContributorUser(FirebasePush[ContributorUser]):
-    model_obj: ContributorUser
-    model = ContributorUser
+class FirebaseContributorUser(FirebasePush[ContributorUser, firebase_ext_models.FbUser]):
+    model_class = ContributorUser
+    firebase_model_class = firebase_ext_models.FbUser
 
     @typing.override
     def handle_new_object_on_firebase(self, model_obj: ContributorUser, fb_reference: FbReference):
@@ -63,7 +69,12 @@ class FirebaseContributorUser(FirebasePush[ContributorUser]):
         raise Exception("User cannot be created from mapswipe-backend")
 
     @typing.override
-    def handle_object_update_on_firebase(self, model_obj: ContributorUser, fb_reference: FbReference):
+    def handle_object_update_on_firebase(
+        self,
+        model_obj: ContributorUser,
+        fb_obj: firebase_ext_models.FbUser,
+        fb_reference: FbReference,
+    ):
         fb_reference.update(
             value=firebase_utils.serialize(
                 firebase_models.FbUserUpdateInput(

--- a/apps/contributor/firebase.py
+++ b/apps/contributor/firebase.py
@@ -67,7 +67,7 @@ class FirebaseContributorUser(FirebasePush[ContributorUser]):
         fb_reference.update(
             value=firebase_utils.serialize(
                 firebase_models.FbUserUpdateInput(
-                    teamId=model_obj.team.firebase_id if model_obj.team else firebase_models.UNDEFINED,
+                    teamId=model_obj.team.firebase_id if model_obj.team else None,
                 ),
             ),
         )

--- a/apps/contributor/management/commands/create_contributor_users.py
+++ b/apps/contributor/management/commands/create_contributor_users.py
@@ -38,9 +38,9 @@ def push_team_member_to_firebase(member: ContributorUser):
     team_member_data = firebase_extended_models.FbUser(
         userName=member.username,
         username=member.username,
-        userNameKey=member.username.lower(),
-        usernameKey=member.username.lower(),
-        teamId=member.team.firebase_id if member.team else firebase_models.UNDEFINED,
+        userNameKey=member.username.lower().strip(),
+        usernameKey=member.username.lower().strip(),
+        teamId=member.team.firebase_id if member.team else None,
         created=timezone.now(),
     )
     fb_reference.set(

--- a/apps/project/firebase.py
+++ b/apps/project/firebase.py
@@ -13,9 +13,9 @@ from main.config import Config
 logger = logging.getLogger(__name__)
 
 
-class FirebaseOrganizationPush(FirebasePush[Organization]):
-    model_obj: Organization
-    model = Organization
+class FirebaseOrganizationPush(FirebasePush[Organization, firebase_models.FbOrganisation]):
+    model_class = Organization
+    firebase_model_class = firebase_models.FbOrganisation
 
     @typing.override
     def handle_new_object_on_firebase(self, model_obj: Organization, fb_reference: FbReference):
@@ -31,7 +31,12 @@ class FirebaseOrganizationPush(FirebasePush[Organization]):
         )
 
     @typing.override
-    def handle_object_update_on_firebase(self, model_obj: Organization, fb_reference: FbReference):
+    def handle_object_update_on_firebase(
+        self,
+        model_obj: Organization,
+        fb_obj: firebase_models.FbOrganisation,
+        fb_reference: FbReference,
+    ):
         fb_reference.update(
             value=firebase_utils.serialize(
                 firebase_models.FbOrganisation(

--- a/apps/project/firebase.py
+++ b/apps/project/firebase.py
@@ -21,13 +21,11 @@ class FirebaseOrganizationPush(FirebasePush[Organization]):
     def handle_new_object_on_firebase(self, model_obj: Organization, fb_reference: FbReference):
         organization_data = firebase_models.FbOrganisation(
             name=model_obj.name,
-            # NOTE: nameKey is is deprecated
-            nameKey="",
-            description=model_obj.description or firebase_models.UNDEFINED,
-            abbreviation=model_obj.abbreviation or firebase_models.UNDEFINED,
+            nameKey=model_obj.name.lower().strip(),
+            description=model_obj.description,
+            abbreviation=model_obj.abbreviation,
             isArchived=model_obj.is_archived,
         )
-
         fb_reference.set(
             value=firebase_utils.serialize(organization_data),
         )
@@ -38,10 +36,9 @@ class FirebaseOrganizationPush(FirebasePush[Organization]):
             value=firebase_utils.serialize(
                 firebase_models.FbOrganisation(
                     name=model_obj.name,
-                    # NOTE: nameKey is is deprecated
-                    nameKey="",
-                    description=model_obj.description or firebase_models.UNDEFINED,
-                    abbreviation=model_obj.abbreviation or firebase_models.UNDEFINED,
+                    nameKey=model_obj.name.lower().strip(),
+                    description=model_obj.description,
+                    abbreviation=model_obj.abbreviation,
                     isArchived=model_obj.is_archived,
                 ),
             ),

--- a/apps/project/graphql/inputs/project_types/completeness.py
+++ b/apps/project/graphql/inputs/project_types/completeness.py
@@ -1,7 +1,6 @@
 import strawberry
 
 from project_types.tile_map_service.completeness import project as completeness_project
-from utils.geo.raster_tile_server.models import RasterTileServerConfig
 
 
 @strawberry.experimental.pydantic.input(model=completeness_project.OverlayVectorTileServerConfig, all_fields=True)
@@ -14,9 +13,7 @@ class ProjectOverlayRasterTileServerConfigInput: ...
 
 # FIXME(tnagorra): Add one_of here?
 @strawberry.experimental.pydantic.input(model=completeness_project.OverlayTileServerConfig, all_fields=True)
-class ProjectOverlayTileServerConfigInput:
-    raster: RasterTileServerConfig | None = strawberry.UNSET
-    vector: completeness_project.OverlayVectorTileServerConfig | None = strawberry.UNSET
+class ProjectOverlayTileServerConfigInput: ...
 
 
 @strawberry.experimental.pydantic.input(model=completeness_project.CompletenessProjectProperty, all_fields=True)

--- a/apps/project/graphql/inputs/project_types/validate.py
+++ b/apps/project/graphql/inputs/project_types/validate.py
@@ -7,6 +7,5 @@ from project_types.validate import project as validate_project
 class ValidateObjectSourceConfigInput: ...
 
 
-# FIXME(tnagorra): Add one_of here?
 @strawberry.experimental.pydantic.input(model=validate_project.ValidateProjectProperty, all_fields=True)
 class ValidateProjectPropertyInput: ...

--- a/apps/project/graphql/inputs/project_types/validate_image.py
+++ b/apps/project/graphql/inputs/project_types/validate_image.py
@@ -3,6 +3,5 @@ import strawberry
 from project_types.validate_image import project as validate_image_project
 
 
-# FIXME(tnagorra): Add one_of here?
 @strawberry.experimental.pydantic.input(model=validate_image_project.ValidateImageProjectProperty, all_fields=True)
 class ValidateImageProjectPropertyInput: ...

--- a/project_types/base/project.py
+++ b/project_types/base/project.py
@@ -200,7 +200,7 @@ class BaseProject[
         fb_tasks: dict[str, dict[str, dict[str, dict]]] = {}
         for task in tasks.iterator():
             task_data = firebase_models.FbMappingTaskCreateOnlyInput(
-                projectId=str(self.project.pk),
+                projectId=self.project.firebase_id,
             )
             task_project_specific_data = self.get_task_project_specifics_for_firebase(task)
             # TODO(tnagorra): Need to group by groups
@@ -219,7 +219,7 @@ class BaseProject[
             group_data = firebase_ext_models.FbMappingGroup(
                 finishedCount=0,
                 progress=0,
-                projectId=str(self.project.pk),
+                projectId=self.project.firebase_id,
                 numberOfTasks=group.number_of_tasks,
                 requiredCount=group.required_count,
             )
@@ -270,37 +270,34 @@ class BaseProject[
 
         project_data = firebase_ext_models.FbProject(
             created=self.project.created_at,
+            # FIXME: use firebase_id later
             createdBy=self.project.created_by.old_id or str(self.project.created_by_id),
-            # FIXME(tnagorra): We need to provide full url
-            # FIXME(tnagorra): Looks like this is required in model currently
-            image=self.project.image.file.url if self.project.image else firebase_models.UNDEFINED,
+            image=self.project.image.file.url if self.project.image else None,
             isFeatured=self.project.is_featured,
             lookFor=self.project.look_for,
-            manualUrl=self.project.additional_info_url or firebase_models.UNDEFINED,
-            maxTasksPerUser=self.project.max_tasks_per_user or firebase_models.UNDEFINED,
+            manualUrl=self.project.additional_info_url,
+            maxTasksPerUser=self.project.max_tasks_per_user,
             groupMaxSize=self.project.group_size,  # this is zero
             contributorCount=0,
             progress=0,
             resultCount=0,
             groupSize=self.project.group_size,
-            projectId=self.project.old_id or str(self.project.id),
+            projectId=self.project.firebase_id,
             name=self.project.generate_name(),
             projectDetails=self.project.description or "n/a",
             projectNumber=self.project.project_number,
             projectRegion=self.project.region,
             projectTopic=self.project.topic,
-            # NOTE: projectTopicKey is obsolete
-            projectTopicKey="",
+            projectTopicKey=self.project.generate_name().lower().strip(),
             projectType=project_type_enum_to_firebase(self.project.project_type_enum),
             # project_type=project_type_enum_to_firebase(self.project.project_type_enum), # not needed here
             requestingOrganisation=self.project.requesting_organization.name,  # str
             requiredResults=self.project.required_results,
             status=status,
-            # FIXME(susilnem): We might need to use old_id
-            teamId=str(self.project.team_id) if self.project.team_id else firebase_models.UNDEFINED,
+            teamId=self.project.team.firebase_id if self.project.team else None,
             # FIXME(tnagorra): Need to check how we get this?
             language="en-us",
-            tutorialId=self.project.tutorial.old_id or str(self.project.tutorial_id),
+            tutorialId=self.project.tutorial.firebase_id,
             verificationNumber=self.project.verification_number,
         )
 
@@ -337,23 +334,19 @@ class BaseProject[
         project_ref.update(
             value=firebase_utils.serialize(
                 firebase_models.FbProjectUpdateInput(
-                    # FIXME(tnagorra): We need to provide full url
-                    # FIXME(tnagorra): Looks like this is required in model currently
-                    image=self.project.image.file.url if self.project.image else firebase_models.UNDEFINED,
+                    image=self.project.image.file.url if self.project.image else None,
                     isFeatured=self.project.is_featured,
                     lookFor=self.project.look_for,
                     name=self.project.generate_name(),
                     projectNumber=self.project.project_number,
                     projectRegion=self.project.region,
                     projectTopic=self.project.topic,
-                    # NOTE: projectTopicKey is obsolete
-                    projectTopicKey="",
+                    projectTopicKey=self.project.generate_name().lower().strip(),
                     projectDetails=self.project.description or "n/a",
                     requestingOrganisation=self.project.requesting_organization.name,
-                    tutorialId=str(self.project.tutorial_id),
+                    tutorialId=self.project.tutorial.firebase_id,
                     status=status,
-                    # FIXME(susilnem): We might need to use old_id
-                    teamId=str(self.project.team_id) if self.project.team_id else firebase_models.UNDEFINED,
+                    teamId=self.project.team.firebase_id if self.project.team else None,
                     # FIXME(tnagorra): Need to check how we get this?
                     language="en-us",
                 ),

--- a/project_types/tile_map_service/compare/project.py
+++ b/project_types/tile_map_service/compare/project.py
@@ -48,7 +48,7 @@ class CompareProject(
 
         return firebase_models.FbMappingTaskCompareCreateOnlyInput(
             groupId=str(task.task_group.firebase_id),
-            taskId=str(task.task_group_id),
+            taskId=task.firebase_id,
             taskX=task_specifics.tile_x,
             taskY=task_specifics.tile_y,
             url=tsp.generate_url(
@@ -75,15 +75,13 @@ class CompareProject(
                 credits=tsp.get_config()["credits"],
                 url=tsp.get_config()["raw_url"],
                 apiKey=tsp.get_config()["api_key"],
-                # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-                wmtsLayerName=firebase_models.UNDEFINED,
+                wmtsLayerName=None,
             ),
             tileServerB=firebase_models.FbObjRasterTileServer(
                 name=raster_tile_server_name_enum_to_firebase(tsp_b.name),
                 credits=tsp_b.get_config()["credits"],
                 url=tsp_b.get_config()["raw_url"],
                 apiKey=tsp_b.get_config()["api_key"],
-                # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-                wmtsLayerName=firebase_models.UNDEFINED,
+                wmtsLayerName=None,
             ),
         )

--- a/project_types/tile_map_service/completeness/project.py
+++ b/project_types/tile_map_service/completeness/project.py
@@ -112,8 +112,7 @@ class CompletenessProject(
             credits=tsp.get_config()["credits"],
             url=tsp.get_config()["raw_url"],
             apiKey=tsp.get_config()["api_key"],
-            # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-            wmtsLayerName=firebase_models.UNDEFINED,
+            wmtsLayerName=None,
         )
 
         # NOTE: Setting background layer as fallback for overlay layer
@@ -124,17 +123,15 @@ class CompletenessProject(
                 credits=tsp_overlay.raster.tile_server.get_config()["credits"],
                 url=tsp_overlay.raster.tile_server.get_config()["raw_url"],
                 apiKey=tsp_overlay.raster.tile_server.get_config()["api_key"],
-                # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-                wmtsLayerName=firebase_models.UNDEFINED,
+                wmtsLayerName=None,
             )
         else:
             fb_overlay_tile_server = firebase_models.FbObjRasterTileServer(
                 name=firebase_models.FbEnumRasterTileServerName.CUSTOM,
-                credits="",
+                credits="n/a",
                 url="https://raw.githubusercontent.com/mapswipe/mapswipe-assets/refs/heads/main/images/raster-layer-404-message.png",
                 apiKey="",
-                # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-                wmtsLayerName=firebase_models.UNDEFINED,
+                wmtsLayerName=None,
             )
 
         return firebase_models.FbProjectCompletenessCreateOnlyInput(
@@ -163,7 +160,7 @@ class CompletenessProject(
                     circleRadius=tsp_overlay.vector.circle_radius,
                 )
                 if tsp_overlay.vector
-                else firebase_models.UNDEFINED,
+                else None,
                 raster=firebase_models.FbObjRasterTileServerOverlay(
                     opacity=tsp_overlay.raster.opacity,
                     tileServer=firebase_models.FbObjRasterTileServer(
@@ -171,11 +168,10 @@ class CompletenessProject(
                         credits=tsp_overlay.raster.tile_server.get_config()["credits"],
                         url=tsp_overlay.raster.tile_server.get_config()["raw_url"],
                         apiKey=tsp_overlay.raster.tile_server.get_config()["api_key"],
-                        # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-                        wmtsLayerName=firebase_models.UNDEFINED,
+                        wmtsLayerName=None,
                     ),
                 )
                 if tsp_overlay.raster
-                else firebase_models.UNDEFINED,
+                else None,
             ),
         )

--- a/project_types/tile_map_service/find/project.py
+++ b/project_types/tile_map_service/find/project.py
@@ -42,7 +42,6 @@ class FindProject(
                 credits=tsp.get_config()["credits"],
                 url=tsp.get_config()["raw_url"],
                 apiKey=tsp.get_config()["api_key"],
-                # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-                wmtsLayerName=firebase_models.UNDEFINED,
+                wmtsLayerName=None,
             ),
         )

--- a/project_types/validate/project.py
+++ b/project_types/validate/project.py
@@ -337,7 +337,7 @@ class ValidateProject(
     @typing.override
     def get_task_project_specifics_for_firebase(self, task: ProjectTask):
         return firebase_models.FbMappingTaskValidateCreateOnlyInput(
-            taskId=str(task.firebase_id),
+            taskId=task.firebase_id,
             # FIXME(tnagorra): Check if we need to convert this?
             geojson=task.geometry,
         )
@@ -345,7 +345,7 @@ class ValidateProject(
     @typing.override
     def get_group_project_specifics_for_firebase(self, group: ProjectTaskGroup):
         return firebase_models.FbMappingGroupValidateCreateOnlyInput(
-            groupId=str(group.firebase_id),
+            groupId=group.firebase_id,
         )
 
     @typing.override
@@ -369,25 +369,22 @@ class ValidateProject(
                         for sub_opt in opt.sub_options
                     ]
                     if opt.sub_options is not None
-                    else firebase_models.UNDEFINED,
+                    else None,
                 )
                 for opt in custom_opts
             ]
             if custom_opts is not None
-            else firebase_models.UNDEFINED,
-            filter=obj_source.ohsome_filter or firebase_models.UNDEFINED,
+            else None,
+            filter=obj_source.ohsome_filter,
             inputType=validate_source_type_enum_to_firebase(
                 obj_source.source_type,
             ),
-            TMId=str(obj_source.tasking_manager_project_id)
-            if obj_source.tasking_manager_project_id
-            else firebase_models.UNDEFINED,
+            TMId=str(obj_source.tasking_manager_project_id) if obj_source.tasking_manager_project_id else None,
             tileServer=firebase_models.FbObjRasterTileServer(
                 name=raster_tile_server_name_enum_to_firebase(tsp.name),
                 credits=tsp.get_config()["credits"],
                 url=tsp.get_config()["raw_url"],
                 apiKey=tsp.get_config()["api_key"],
-                # NOTE: wmtsLayerName is deprecated as singergise is not longer supported
-                wmtsLayerName=firebase_models.UNDEFINED,
+                wmtsLayerName=None,
             ),
         )

--- a/project_types/validate_image/project.py
+++ b/project_types/validate_image/project.py
@@ -50,14 +50,14 @@ class ValidateImageProject(
             **task.project_type_specifics,
         )
         return firebase_models.FbMappingTaskValidateImageCreateOnlyInput(
-            taskId=str(task.firebase_id),
-            question=task_specifics.question or firebase_models.UNDEFINED,
+            taskId=task.firebase_id,
+            question=task_specifics.question,
         )
 
     @typing.override
     def get_group_project_specifics_for_firebase(self, group):
         return firebase_models.FbMappingGroupValidateImageCreateOnlyInput(
-            groupId=str(group.firebase_id),
+            groupId=group.firebase_id,
         )
 
     # TODO(tnagorra): Define validate
@@ -86,10 +86,10 @@ class ValidateImageProject(
                         for sub_opt in opt.sub_options
                     ]
                     if opt.sub_options is not None
-                    else firebase_models.UNDEFINED,
+                    else None,
                 )
                 for opt in custom_opts
             ]
             if custom_opts is not None
-            else firebase_models.UNDEFINED,
+            else None,
         )


### PR DESCRIPTION
## Depends on

- https://github.com/mapswipe/mapswipe-firebase/pull/20

## Changes

- firebase: send null to firebase if data is missing
- firebase: use firebase_id instead of id or old_id where missing
- firebase: update use of latest firebase schema (with deprecation support)
- firebase: remove deprecated comments
- firebase: define projectTopicKey, usernameKey nameKey
- firebase: fix issue with required projectDetails field
- pydantic: fix warning on usage of pydantic.input all_fieldsAddresses
- firebase: validate data before updating the data
- firebase: add inheritance checks to FirebasePush

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
