### PR TITLE
ContributorUser: Cannot add member to archived team.

### DIFF
--- a/apps/contributor/models.py
+++ b/apps/contributor/models.py
@@ -34,6 +34,14 @@ class ContributorUser(FirebasePushResource):
     def __str__(self):
         return self.username
 
+    @typing.override
+    def clean(self):
+        super().clean()
+        if self.team and self.team.is_archived:
+            raise ValidationError(
+                {"team": gettext("Cannot create or update member to archived team.")},
+            )
+
 
 class ContributorUserGroup(ArchivableResource, UserResource, FirebasePushResource):  # type: ignore[reportIncompatibleVariableOverride]
     name = models.CharField(max_length=255)
@@ -93,7 +101,7 @@ class ContributorTeam(ArchivableResource, UserResource, FirebasePushResource):  
 
     @typing.override
     def __str__(self):
-        return self.name
+        return f"Archived - {self.name}" if self.is_archived else self.name
 
     @typing.override
     def clean(self):

--- a/apps/contributor/tests/contributor_team_test.py
+++ b/apps/contributor/tests/contributor_team_test.py
@@ -47,3 +47,10 @@ class TestContributorTeam(TestCase):
         self.admin.save_model(request, self.contributor_team, form=None, change=True)  # type: ignore[reportArgumentType]
         assert self.contributor_team.is_archived is True
         assert self.contributor_team.archived_by == self.user
+
+    def test_cannot_add_member_to_archived_team(self):
+        self.contributor_team.is_archived = True
+        self.contributor_team.save(update_fields=["is_archived"])
+        self.contributor_user.team = self.contributor_team
+        with pytest.raises(ValidationError):
+            self.contributor_user.clean()


### PR DESCRIPTION
## Changes
- modify contributor user admin form to get only non-archived team.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
