### PR TITLE
fix(tileserver): rename quadkey to quad_key

### DIFF
--- a/utils/common.py
+++ b/utils/common.py
@@ -14,7 +14,7 @@ from geojson_pydantic import FeatureCollection
 from ulid import ULID
 
 
-def validate_imagery_url(url: str, *, support_quadkey: bool | None = True):
+def validate_imagery_url(url: str, *, support_quad_key: bool | None = True):
     """Check if imagery url contains xyz or quad key placeholders."""
     if all([substring in url for substring in ["{x}", "{y}", "{z}"]]) and not any(
         [substring in url for substring in ["{{x}}", "{{y}}", "{{z}}"]],
@@ -24,13 +24,13 @@ def validate_imagery_url(url: str, *, support_quadkey: bool | None = True):
         [substring in url for substring in ["{{x}}", "{{-y}}", "{{z}}"]],
     ):
         return
-    # NOTE: We are using quadkey instead of quad_key because client-side libraries directly supports quadkey
-    if support_quadkey and ("{quadkey}" in url and "{{quadkey}}" not in url):
+    # NOTE: We are using quad_key instead of quad_key because client-side libraries directly supports quad_key
+    if support_quad_key and ("{quad_key}" in url and "{{quad_key}}" not in url):
         return
 
-    if support_quadkey:
+    if support_quad_key:
         raise ValidationError(
-            gettext("The imagery url '%s' must contain {x}, {y} (or {-y}) and {z} or the {quadkey} placeholders.") % url,
+            gettext("The imagery url '%s' must contain {x}, {y} (or {-y}) and {z} or the {quad_key} placeholders.") % url,
         )
     raise ValidationError(
         gettext("The imagery url '%s' must contain {x}, {y} (or {-y}) and {z} placeholders.") % url,

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -22,13 +22,13 @@ def _validate_url(value: typing.Any):
 
 def _validate_raster_tile_url(value: typing.Any):
     url = _validate_url(value)
-    validate_imagery_url(value, support_quadkey=True)
+    validate_imagery_url(value, support_quad_key=True)
     return url
 
 
 def _validate_vector_tile_url(value: typing.Any):
     url = _validate_url(value)
-    validate_imagery_url(value, support_quadkey=False)
+    validate_imagery_url(value, support_quad_key=False)
     return url
 
 

--- a/utils/geo/raster_tile_server/config.py
+++ b/utils/geo/raster_tile_server/config.py
@@ -59,7 +59,7 @@ class RasterConfig:
         match name:
             case RasterTileServerNameEnum.BING:
                 api_key = settings.MAP_IMAGE_BING_API_KEY
-                url = "https://ecn.t0.tiles.virtualearth.net/tiles/a{{quadkey}}.jpeg?g=7505&token={apiKey}"
+                url = "https://ecn.t0.tiles.virtualearth.net/tiles/a{{quad_key}}.jpeg?g=7505&token={apiKey}"
                 return {
                     "url": url.format(apiKey=api_key),
                     "raw_url": url.format(apiKey="{apiKey}"),

--- a/utils/geo/raster_tile_server/models.py
+++ b/utils/geo/raster_tile_server/models.py
@@ -3,7 +3,7 @@ import typing
 from pydantic import BaseModel, field_validator, model_validator
 
 from utils import fields as custom_fields
-from utils.geo.tile_functions import tile_coords_and_zoom_to_quadKey
+from utils.geo.tile_functions import tile_coords_and_zoom_to_quad_key
 
 from .config import RasterConfig, RasterTileServerNameEnum, RasterTileServerNormConfig
 
@@ -41,10 +41,10 @@ class RasterTileServerConfig(BaseModel):
 
     def generate_url(self, tile_x: int, tile_y: int, tile_z: int) -> str:
         url = self.get_config()["url"]
-        if "{quadkey}" in url:
-            quadkey = tile_coords_and_zoom_to_quadKey(tile_x, tile_y, tile_z)
+        if "{quad_key}" in url:
+            quad_key = tile_coords_and_zoom_to_quad_key(tile_x, tile_y, tile_z)
             return url.format(
-                quadkey=quadkey,
+                quad_key=quad_key,
             )
         return url.format(
             x=tile_x,

--- a/utils/geo/tile_functions.py
+++ b/utils/geo/tile_functions.py
@@ -73,10 +73,10 @@ def pixel_coords_to_tile_address(pixel_x: float, pixel_y: float):
     return t
 
 
-def tile_coords_and_zoom_to_quadKey(tile_x: int, tile_y: int, zoom: int) -> str:
-    """Create a quadkey for use with certain tileservers that use them, e.g. Bing."""
+def tile_coords_and_zoom_to_quad_key(tile_x: int, tile_y: int, zoom: int) -> str:
+    """Create a quad_key for use with certain tileservers that use them, e.g. Bing."""
 
-    quadKey = ""
+    quad_key = ""
     for i in range(zoom, 0, -1):
         digit = 0
         mask = 1 << (i - 1)
@@ -84,15 +84,15 @@ def tile_coords_and_zoom_to_quadKey(tile_x: int, tile_y: int, zoom: int) -> str:
             digit += 1
         if (tile_y & mask) != 0:
             digit += 2
-        quadKey += str(digit)
-    return quadKey
+        quad_key += str(digit)
+    return quad_key
 
 
 # FIXME(tnagorra): This is not used.
-def quadkey_to_bing_url(quadkey: str, api_key: str):
+def quad_key_to_bing_url(quad_key: str, api_key: str):
     """Create a tile image URL linking to a Bing tile server."""
     # FIXME(tnagorra): We should not hardcode the urls
-    return f"https://ecn.t0.tiles.virtualearth.net/tiles/a{quadkey}.jpeg?g=7505&mkt=en-US&token={api_key}"
+    return f"https://ecn.t0.tiles.virtualearth.net/tiles/a{quad_key}.jpeg?g=7505&mkt=en-US&token={api_key}"
 
 
 # FIXME(tnagorra): Add typings for osgeo

--- a/utils/tests/common_test.py
+++ b/utils/tests/common_test.py
@@ -36,7 +36,7 @@ class TestUtils(TestCase):
         valid_urls = [
             "https://example.com/tiles/{x}/{y}/{z}.jpg",
             "https://tileserver.com/tiles/{z}/{x}/{-y}.png",
-            "https://tileserver.com/tiles/{quadkey}.png",
+            "https://tileserver.com/tiles/{quad_key}.png",
         ]
         for url in valid_urls:
             validate_imagery_url(url)
@@ -47,11 +47,11 @@ class TestUtils(TestCase):
 
         url = "https://tileserver.com/tiles/invalid.png"
         with pytest.raises(ValidationError):
-            validate_imagery_url(url, support_quadkey=True)
+            validate_imagery_url(url, support_quad_key=True)
 
         url = "https://tileserver.com/tiles/{a}/{b}/{c}.png"
         with pytest.raises(ValidationError):
-            validate_imagery_url(url, support_quadkey=False)
+            validate_imagery_url(url, support_quad_key=False)
 
     def test_validate_ulid(self):
         # test valid ulid
@@ -188,8 +188,8 @@ class TestUtils(TestCase):
         url = "https://example.com/tiles/{x}/{y}/{z}.jpg"
         _validate_raster_tile_url(url)
 
-        # test with quadkey in url
-        url = "https://tileserver.com/tiles/{quadkey}.png"
+        # test with quad_key in url
+        url = "https://tileserver.com/tiles/{quad_key}.png"
         _validate_raster_tile_url(url)
 
         # test invalid url
@@ -211,8 +211,8 @@ class TestUtils(TestCase):
         with pytest.raises(ValidationError):
             _validate_vector_tile_url(url)
 
-        # test url with quadkey should throw value error
-        url = "https://tileserver.com/tiles/{quadkey}.png"
+        # test url with quad_key should throw value error
+        url = "https://tileserver.com/tiles/{quad_key}.png"
         with pytest.raises(ValidationError):
             _validate_vector_tile_url(url)
 


### PR DESCRIPTION
## Changes

- previously we were using quad_key
- maplibre uses quadkey by default

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
