### PR TITLE
Admin: make admin fields readonly

### DIFF
--- a/apps/common/admin.py
+++ b/apps/common/admin.py
@@ -117,3 +117,15 @@ class ReadOnlyAdmin(admin.ModelAdmin):
     def get_readonly_fields(self, request, obj=None):
         # Get all model field names
         return [f.name for f in self.model._meta.fields]
+
+    @typing.override
+    def has_add_permission(self, *args, **kwargs):
+        return False
+
+    @typing.override
+    def has_delete_permission(self, *args, **kwargs):
+        return False
+
+    @typing.override
+    def has_change_permission(self, request, obj=None):
+        return False

--- a/apps/common/admin.py
+++ b/apps/common/admin.py
@@ -110,3 +110,10 @@ class FirebaseResourceAdmin(UserResourceAdmin, admin.ModelAdmin):
                 ],
             ),
         ]
+
+
+class ReadOnlyAdmin(admin.ModelAdmin):
+    @typing.override
+    def get_readonly_fields(self, request, obj=None):
+        # Get all model field names
+        return [f.name for f in self.model._meta.fields]

--- a/apps/contributor/admin.py
+++ b/apps/contributor/admin.py
@@ -54,7 +54,6 @@ class ContributorTeamAdmin(
     ArchivableResourceAdmin,
     DjangoQLSearchMixin,
     FirebaseResourceAdmin,
-    ReadOnlyAdmin,
     admin.ModelAdmin,
 ):
     list_display = (

--- a/apps/contributor/admin.py
+++ b/apps/contributor/admin.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 from djangoql.admin import DjangoQLSearchMixin
 
-from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin
+from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin, ReadOnlyAdmin
 
 from .firebase import FirebaseContributorTeam, FirebaseContributorUser
 from .models import ContributorTeam, ContributorUser, ContributorUserGroup, ContributorUserGroupMembership
@@ -45,12 +45,18 @@ class ContributorUserAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
 
 
 @admin.register(ContributorUserGroup)
-class ContributorUserGroupAdmin(DjangoQLSearchMixin, ArchivableResourceAdmin, FirebaseResourceAdmin):
+class ContributorUserGroupAdmin(DjangoQLSearchMixin, ArchivableResourceAdmin, FirebaseResourceAdmin, ReadOnlyAdmin):
     pass
 
 
 @admin.register(ContributorTeam)
-class ContributorTeamAdmin(ArchivableResourceAdmin, DjangoQLSearchMixin, FirebaseResourceAdmin, admin.ModelAdmin):
+class ContributorTeamAdmin(
+    ArchivableResourceAdmin,
+    DjangoQLSearchMixin,
+    FirebaseResourceAdmin,
+    ReadOnlyAdmin,
+    admin.ModelAdmin,
+):
     list_display = (
         "name",
         "is_archived",
@@ -71,7 +77,7 @@ class ContributorTeamAdmin(ArchivableResourceAdmin, DjangoQLSearchMixin, Firebas
 
 
 @admin.register(ContributorUserGroupMembership)
-class ContributorUserGroupMembershipAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+class ContributorUserGroupMembershipAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
     list_display = (
         "user",
         "user_group",

--- a/apps/project/admin.py
+++ b/apps/project/admin.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 from djangoql.admin import DjangoQLSearchMixin
 
-from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin
+from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin, ReadOnlyAdmin
 
 from .models import Organization, Project, ProjectAsset
 
@@ -36,13 +36,19 @@ class IncludedInTeamFilter(admin.SimpleListFilter):
 
 
 @admin.register(Organization)
-class OrganizationAdmin(DjangoQLSearchMixin, ArchivableResourceAdmin, FirebaseResourceAdmin, admin.ModelAdmin):
+class OrganizationAdmin(
+    DjangoQLSearchMixin,
+    ArchivableResourceAdmin,
+    FirebaseResourceAdmin,
+    ReadOnlyAdmin,
+    admin.ModelAdmin,
+):
     list_display = ("name",)
     list_filter = ("name",)
 
 
 @admin.register(Project)
-class ProjectAdmin(DjangoQLSearchMixin, FirebaseResourceAdmin, admin.ModelAdmin):
+class ProjectAdmin(DjangoQLSearchMixin, FirebaseResourceAdmin, ReadOnlyAdmin, admin.ModelAdmin):
     list_display = ("topic", "requesting_organization", "project_type", "is_private", "region")
     list_filter = (IncludedInTeamFilter, "topic", "project_type", "is_private", "region")
     list_select_related = True
@@ -50,5 +56,5 @@ class ProjectAdmin(DjangoQLSearchMixin, FirebaseResourceAdmin, admin.ModelAdmin)
 
 
 @admin.register(ProjectAsset)
-class ProjectAssetAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+class ProjectAssetAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
     pass

--- a/apps/tutorial/admin.py
+++ b/apps/tutorial/admin.py
@@ -1,11 +1,13 @@
 from django.contrib import admin
 from djangoql.admin import DjangoQLSearchMixin
 
+from apps.common.admin import ReadOnlyAdmin
+
 from .models import Tutorial, TutorialAsset
 
 
 @admin.register(Tutorial)
-class TutorialAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+class TutorialAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
     list_display = ("name", "project", "status")
     list_filter = ("status",)
     list_select_related = True
@@ -13,5 +15,5 @@ class TutorialAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
 
 
 @admin.register(TutorialAsset)
-class ProjectAssetAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+class ProjectAssetAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
     pass

--- a/apps/user/admin.py
+++ b/apps/user/admin.py
@@ -3,6 +3,8 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.utils.translation import gettext_lazy as _
 
+from apps.common.admin import ReadOnlyAdmin
+
 from .models import User
 
 
@@ -13,7 +15,7 @@ class UserCreationForm(forms.ModelForm):
 
 
 @admin.register(User)
-class UserAdmin(DjangoUserAdmin):
+class UserAdmin(DjangoUserAdmin, ReadOnlyAdmin):
     list_display = (
         "email",
         "contributor_user__firebase_id",


### PR DESCRIPTION
## Changes
- Add ReadOnlyAdmin class and applied to other admin class.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
