### PR TITLE
StatusChangeApi: add mutation for updating status

### DIFF
--- a/apps/project/graphql/inputs/inputs.py
+++ b/apps/project/graphql/inputs/inputs.py
@@ -79,7 +79,6 @@ class ProjectUpdateInput(UserResourceTopLevelUpdateInputMixin):
     verification_number: strawberry.auto
     group_size: strawberry.auto
     max_tasks_per_user: strawberry.auto
-    status: strawberry.auto
     tutorial: strawberry.ID | None = strawberry.UNSET
     requesting_organization: strawberry.ID | None = strawberry.UNSET
     image: strawberry.ID | None = strawberry.UNSET
@@ -101,6 +100,11 @@ class ProcessedProjectUpdateInput(UserResourceTopLevelUpdateInputMixin):
     requesting_organization: strawberry.ID | None = strawberry.UNSET
     image: strawberry.ID | None = strawberry.UNSET
     team: strawberry.ID | None = strawberry.UNSET
+
+
+@strawberry_django.partial(Project)
+class ProjectStatusUpdateInput(UserResourceTopLevelUpdateInputMixin):
+    status: strawberry.auto
 
 
 # NOTE: Make sure this matches with the serializers ../serializers.py

--- a/apps/project/graphql/mutations.py
+++ b/apps/project/graphql/mutations.py
@@ -8,6 +8,7 @@ from apps.project.serializers import (
     ProcessedProjectSerializer,
     ProjectAssetSerializer,
     ProjectCreateSerializer,
+    ProjectStatusUpdateSerializer,
     ProjectUpdateSerializer,
 )
 from main.graphql.context import Info
@@ -20,9 +21,10 @@ from .inputs.inputs import (
     ProcessedProjectUpdateInput,
     ProjectAssetCreateInput,
     ProjectCreateInput,
+    ProjectStatusUpdateInput,
     ProjectUpdateInput,
 )
-from .types.types import OrganizationType, ProjectAssetType, ProjectType
+from .types.types import OrganizationType, ProjectAssetType, ProjectStatusType, ProjectType
 
 
 @strawberry.type
@@ -78,3 +80,13 @@ class Mutation:
     ) -> MutationResponseType[OrganizationType]:
         organization = await Organization.objects.aget(pk=pk)
         return await ModelMutation(OrganizationSerializer).handle_update_mutation(data, info, organization)
+
+    @strawberry_django.mutation(extensions=[IsAuthenticated()])
+    async def update_project_status(
+        self,
+        info: Info,
+        data: ProjectStatusUpdateInput,
+        pk: strawberry.ID,
+    ) -> MutationResponseType[ProjectStatusType]:
+        project = await Project.objects.aget(pk=pk)
+        return await ModelMutation(ProjectStatusUpdateSerializer).handle_update_mutation(data, info, project)

--- a/apps/project/graphql/types/types.py
+++ b/apps/project/graphql/types/types.py
@@ -20,11 +20,18 @@ from .asset_types import AoiGeometryAssetPropertyType, ObjectImageAssetPropertyT
 # NOTE: We are importing base for side-effect
 # The tile server types are required by the following imports
 from .project_types import base  # noqa: F401  # isort: skip # type: ignore[reportUnusedImport]
+
 from .project_types.compare import CompareProjectPropertyType
 from .project_types.completeness import CompletenessProjectPropertyType
 from .project_types.find import FindProjectPropertyType
 from .project_types.validate import ValidateProjectPropertyType
 from .project_types.validate_image import ValidateImageProjectPropertyType
+
+
+@strawberry_django.type(Project)
+class ProjectStatusType:
+    id: strawberry.ID
+    status: strawberry.auto
 
 
 # Organization

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -31,15 +31,7 @@ VALID_PROJECT_STATUS_TRANSITIONS = set(
         (Project.Status.DRAFT, Project.Status.DISCARDED),
         (Project.Status.FAILED, Project.Status.MARKED_AS_READY),
         (Project.Status.FAILED, Project.Status.DISCARDED),
-    ],
-)
-
-
-VALID_PROCESSED_PROJECT_STATUS_TRANSITIONS = set(
-    [
         # NOTE: Transition from MARKED_AS_READY are updated by the system
-        # (Project.Status.MARKED_AS_READY, Project.Status.FAILED),
-        # (Project.Status.MARKED_AS_READY, Project.Status.READY),
         (Project.Status.READY, Project.Status.PUBLISHED),
         (Project.Status.READY, Project.Status.DISCARDED),
         (Project.Status.PUBLISHED, Project.Status.ARCHIVED),
@@ -102,7 +94,6 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
             "group_size",
             "max_tasks_per_user",
             "project_type_specifics",
-            "status",
             "tutorial",
             "team",
         )
@@ -113,25 +104,6 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
                 gettext("Cannot use archived team on a project."),
             )
         return team
-
-    def validate_status(self, new_status: Project.Status | int) -> Project.Status:
-        assert self.instance is not None, "Project does not exist."
-
-        if not isinstance(new_status, Project.Status):
-            new_status = Project.Status(new_status)
-
-        if (
-            self.instance.status_enum != new_status
-            and (self.instance.status_enum, new_status) not in VALID_PROJECT_STATUS_TRANSITIONS
-        ):
-            raise serializers.ValidationError(
-                gettext("Project status cannot be changed from %s to %s")
-                % (
-                    self.instance.status_enum.label,
-                    new_status.label,
-                ),
-            )
-        return new_status
 
     def validate_tutorial(self, tutorial: Tutorial | None) -> Tutorial | None:
         assert self.instance is not None
@@ -232,16 +204,6 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
         self._validate_project_type_specifics(attrs)
         return super().validate(attrs)
 
-    @typing.override
-    def update(self, instance: Project, validated_data: dict[str, typing.Any]) -> Project:  # type: ignore[reportIncompatibleMethodOverride]
-        old_status_enum = instance.status_enum
-        new_project = super().update(instance, validated_data)
-
-        if old_status_enum != Project.Status.MARKED_AS_READY and new_project.status_enum == Project.Status.MARKED_AS_READY:
-            transaction.on_commit(lambda: process_project_task.delay(new_project.pk))
-
-        return new_project
-
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
 class ProcessedProjectSerializer(UserResourceSerializer[Project]):
@@ -261,7 +223,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
             "additional_info_url",
             "description",
             "image",
-            "status",
             "tutorial",
             "team",
         )
@@ -272,22 +233,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
                 gettext("Cannot use archived team on a project."),
             )
         return team
-
-    def validate_status(self, new_status: Project.Status | int):
-        assert self.instance is not None, "Project does not exist."
-
-        if not isinstance(new_status, Project.Status):
-            new_status = Project.Status(new_status)
-
-        if (
-            self.instance.status_enum != new_status
-            and (self.instance.status_enum, new_status) not in VALID_PROCESSED_PROJECT_STATUS_TRANSITIONS
-        ):
-            raise serializers.ValidationError(
-                gettext("Project status cannot be changed from %s to %s")
-                % (self.instance.status_enum.label, new_status.label),
-            )
-        return new_status
 
     def validate_image(self, new_image: ProjectAsset | None):
         assert self.instance is not None
@@ -317,11 +262,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
         current_tutorial = self.instance.tutorial
         tutorial = new_tutorial or current_tutorial
 
-        if tutorial is None and attrs.get("status") == Project.Status.PUBLISHED:
-            raise serializers.ValidationError(
-                {"tutorial": gettext("Tutorial is required before publishing a project.")},
-            )
-
         # FIXME(susilnem): Check if we should use new_tutorial.status or new_status.status_enum
         if new_tutorial and new_tutorial != current_tutorial and new_tutorial.status_enum == Tutorial.Status.ARCHIVED:
             raise serializers.ValidationError(gettext("Cannot assign archived tutorial to the project."))
@@ -339,21 +279,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
 
         self._validate_tutorial(attrs)
         return super().validate(attrs)
-
-    @typing.override
-    def update(self, instance: Project, validated_data: dict[str, typing.Any]) -> Project:
-        old_status_enum = instance.status_enum
-        updated_project = super().update(instance, validated_data)
-
-        if (
-            old_status_enum != Project.Status.PUBLISHED and updated_project.status_enum == Project.Status.PUBLISHED
-        ) or old_status_enum == Project.Status.PUBLISHED:
-            updated_project.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-
-            # FIXME: We can call this on batch later as well or handle error scenario
-            transaction.on_commit(lambda: push_project_to_firebase.delay(updated_project.pk))
-
-        return updated_project
 
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
@@ -490,3 +415,59 @@ class OrganizationSerializer(UserResourceSerializer[Organization], ArchivableRes
         organization = super().update(instance, validated_data)
         FirebaseOrganizationPush(organization).trigger()
         return organization
+
+
+class ProjectStatusUpdateSerializer(UserResourceSerializer[Project]):
+    class Meta:  # type: ignore[reportIncompatibleVariableOverride]
+        model = Project
+        fields = ("status",)
+
+    def validate_status(self, new_status: Project.Status | int) -> Project.Status:
+        assert self.instance is not None, "Project does not exist."
+
+        if not isinstance(new_status, Project.Status):
+            new_status = Project.Status(new_status)
+
+        if (
+            self.instance.status_enum != new_status
+            and (self.instance.status_enum, new_status) not in VALID_PROJECT_STATUS_TRANSITIONS
+        ):
+            raise serializers.ValidationError(
+                gettext("Project status cannot be changed from %s to %s")
+                % (
+                    self.instance.status_enum.label,
+                    new_status.label,
+                ),
+            )
+
+        if new_status == Project.Status.PUBLISHED and not self.instance.tutorial:
+            raise serializers.ValidationError(
+                {"tutorial": gettext("Tutorial is required before publishing a project.")},
+            )
+        if new_status == Project.Status.MARKED_AS_READY and not self.instance.project_type_specifics:
+            raise serializers.ValidationError(
+                gettext("project_type_specifics is required when project status is %s") % (new_status.label),
+            )
+
+        return new_status
+
+    @typing.override
+    def update(self, instance: Project, validated_data: dict[str, typing.Any]) -> Project:  # type: ignore[reportIncompatibleMethodOverride]
+        old_status_enum = instance.status_enum
+        updated_project = super().update(instance, validated_data)
+
+        if (
+            old_status_enum != Project.Status.MARKED_AS_READY
+            and updated_project.status_enum == Project.Status.MARKED_AS_READY
+        ):
+            transaction.on_commit(lambda: process_project_task.delay(updated_project.pk))
+
+        if (
+            old_status_enum != Project.Status.PUBLISHED and updated_project.status_enum == Project.Status.PUBLISHED
+        ) or old_status_enum == Project.Status.PUBLISHED:
+            updated_project.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
+
+            # FIXME: We can call this on batch later as well or handle error scenario
+            transaction.on_commit(lambda: push_project_to_firebase.delay(updated_project.pk))
+
+        return updated_project

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -290,6 +290,29 @@ class Mutation:
           }
         }
     """
+    UPDATE_PROJECT_STATUS = """
+        mutation UpdateProjectStatus($pk: ID!, $data: ProjectStatusUpdateInput!) {
+          updateProjectStatus(pk: $pk, data: $data) {
+            ... on OperationInfo {
+              __typename
+              messages {
+                code
+                field
+                kind
+                message
+              }
+            }
+            ... on ProjectStatusTypeMutationResponseType {
+              errors
+              ok
+              result {
+                id
+                status
+              }
+            }
+          }
+        }
+    """
 
 
 class TestOrganizationMutation(TestCase):
@@ -490,6 +513,16 @@ class TestProjectMutation(TestCase):
                 **kwargs,
             )
 
+    def _update_project_status_mutation(self, pk: str, project_data: dict, **kwargs):
+        with self.captureOnCommitCallbacks(execute=True):
+            return update_project_query(
+                query_check_func=self.query_check,
+                query=Mutation.UPDATE_PROJECT_STATUS,
+                pk=pk,
+                project_data=project_data,
+                **kwargs,
+            )
+
     def test_project_create(self):
         project_data = {
             "clientId": str(ULID()),
@@ -682,13 +715,13 @@ class TestProjectMutation(TestCase):
             "clientId": proj.client_id,
             "status": self.genum(Project.Status.MARKED_AS_READY),
         }
-        content = self._update_project_mutation(str(latest_project.pk), project_data)
-        assert content["data"]["updateProject"]["errors"] == [
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] == [
             {
                 "array_errors": None,
                 "client_id": latest_project.client_id,
-                "field": "projectTypeSpecifics",
-                "messages": "Configuration not provided for Find",
+                "field": "status",
+                "messages": "project_type_specifics is required when project status is Marked as Ready",
                 "object_errors": None,
                 "pydantic_errors": None,
             },
@@ -814,8 +847,8 @@ class TestProjectMutation(TestCase):
             "clientId": proj.client_id,
             "status": self.genum(Project.Status.MARKED_AS_READY),
         }
-        content = self._update_project_mutation(str(latest_project.pk), project_data)
-        assert content["data"]["updateProject"]["errors"] is None
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] is None
 
         mock_requests.assert_called_once()
         mock_requests.assert_has_calls([call(latest_project.pk)])
@@ -843,29 +876,44 @@ class TestProjectMutation(TestCase):
             project=latest_project,
             status=Tutorial.Status.ARCHIVED,
         )
+
         project_data = {
             "clientId": proj.client_id,
-            "status": self.genum(Project.Status.PUBLISHED),
             "tutorial": self.gID(archived_tutorial.pk),
         }
         content = self._update_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProject"]["errors"] is not None
 
-        # Unarchiving Tutorial
-        archived_tutorial.status = Tutorial.Status.PUBLISHED
-        archived_tutorial.save(update_fields=["status"])
-
+        # Publish a project
+        # set unarchived tutorial to project before publishing a project
+        tutorial = TutorialFactory.create(
+            **self.user_resource_kwargs,
+            project=latest_project,
+            status=Tutorial.Status.PUBLISHED,
+        )
+        project_data = {
+            "clientId": proj.client_id,
+            "tutorial": tutorial.id,
+        }
         content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProcessedProject"]["errors"] is None, content
-
-        # Archiving tutorial
-        # Test Pass as archiving tutorial does not affect project on published projects
-        archived_tutorial.status = Tutorial.Status.ARCHIVED
-        archived_tutorial.save(update_fields=["status"])
+        latest_project.refresh_from_db()
 
         project_data = {
             "clientId": proj.client_id,
-            "tutorial": self.gID(archived_tutorial.pk),
+            "status": self.genum(Project.Status.PUBLISHED),
+        }
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] is None
+        latest_project.refresh_from_db()
+
+        # Archiving tutorial
+        # Test Pass as archiving tutorial does not affect project on published projects
+        tutorial.status = Tutorial.Status.ARCHIVED
+        tutorial.save(update_fields=["status"])
+        project_data = {
+            "clientId": proj.client_id,
+            "tutorial": self.gID(tutorial.pk),
         }
         content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProcessedProject"]["errors"] is None, content
@@ -875,9 +923,9 @@ class TestProjectMutation(TestCase):
             "clientId": proj.client_id,
             "status": self.genum(ProjectStatusEnum.ARCHIVED),
         }
-        content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
-        assert content["data"]["updateProcessedProject"]["errors"] is None, content
-        assert content["data"]["updateProcessedProject"]["result"]["status"] == self.genum(ProjectStatusEnum.ARCHIVED)
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] is None, content
+        assert content["data"]["updateProjectStatus"]["result"]["status"] == self.genum(ProjectStatusEnum.ARCHIVED)
 
         # Updating project with archived team
         # fails as team is archived
@@ -989,6 +1037,16 @@ class TestProjectTypeMutation(TestCase):
             return update_project_query(
                 query_check_func=self.query_check,
                 query=Mutation.UPDATE_PROJECT,
+                pk=pk,
+                project_data=project_data,
+                **kwargs,
+            )
+
+    def _update_project_status_mutation(self, pk: str, project_data: dict, **kwargs):
+        with self.captureOnCommitCallbacks(execute=True):
+            return update_project_query(
+                query_check_func=self.query_check,
+                query=Mutation.UPDATE_PROJECT_STATUS,
                 pk=pk,
                 project_data=project_data,
                 **kwargs,
@@ -1146,11 +1204,12 @@ class TestProjectTypeMutation(TestCase):
             "clientId": project_client_id,
             "status": self.genum(Project.Status.MARKED_AS_READY),
         }
-        content = self._update_project_mutation(project_id, project_data)
-        resp_data = content["data"]["updateProject"]
+        content = self._update_project_status_mutation(project_id, project_data)
+        resp_data = content["data"]["updateProjectStatus"]
         assert resp_data["errors"] is None, content
         assert resp_data["result"]["status"] == self.genum(Project.Status.MARKED_AS_READY)
-        assert resp_data["result"]["processingStatus"] is None
+        latest_project.refresh_from_db()
+        assert latest_project.processing_status is None
 
         mock_requests.assert_called_once()
         mock_requests.assert_has_calls([call(int(project_id))])
@@ -1293,9 +1352,7 @@ class TestProjectTypeMutation(TestCase):
             "clientId": project_client_id,
             "status": self.genum(Project.Status.PUBLISHED),
         }
-        content = self._update_processed_project_mutation(project_id, project_data)
-        resp_data = content["data"]["updateProcessedProject"]
-        assert resp_data["errors"] is not None, content
+        content = self._update_project_status_mutation(project_id, project_data, assert_errors=True)
 
         # Updating Processed Project:
         # Attaching tutorial
@@ -1314,8 +1371,10 @@ class TestProjectTypeMutation(TestCase):
             "clientId": project_client_id,
             "status": self.genum(Project.Status.PUBLISHED),
         }
-        content = self._update_processed_project_mutation(project_id, project_data)
-        resp_data = content["data"]["updateProcessedProject"]
+        content = self._update_project_status_mutation(project_id, project_data)
+        resp_data = content["data"]["updateProjectStatus"]
         assert resp_data["errors"] is None, content
         assert resp_data["result"]["status"] == self.genum(Project.Status.PUBLISHED)
-        assert resp_data["result"]["processingStatus"] == self.genum(Project.ProcessingStatus.COMPLETED)
+
+        latest_project.refresh_from_db()
+        assert latest_project.processing_status == Project.ProcessingStatus.COMPLETED

--- a/schema.graphql
+++ b/schema.graphql
@@ -842,6 +842,7 @@ type Mutation {
   createProjectAsset(data: ProjectAssetCreateInput!): CreateProjectAssetPayload! @isAuthenticated
   createOrganization(data: OrganizationCreateInput!): CreateOrganizationPayload! @isAuthenticated
   updateOrganization(data: OrganizationUpdateInput!, pk: ID!): UpdateOrganizationPayload! @isAuthenticated
+  updateProjectStatus(data: ProjectStatusUpdateInput!, pk: ID!): UpdateProjectStatusPayload! @isAuthenticated
   deleteTutorial: DeleteTutorialPayload! @isAuthenticated
   createTutorial(data: TutorialCreateInput!): CreateTutorialPayload! @isAuthenticated
   updateTutorial(data: TutorialUpdateInput!, pk: ID!): UpdateTutorialPayload! @isAuthenticated
@@ -1538,6 +1539,28 @@ input ProjectStatusEnumFilterLookup {
 """
 Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
 """
+type ProjectStatusType {
+  id: ID!
+  status: ProjectStatusEnum!
+}
+
+type ProjectStatusTypeMutationResponseType {
+  ok: Boolean!
+  errors: CustomErrorType
+  result: ProjectStatusType
+}
+
+"""
+Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
+"""
+input ProjectStatusUpdateInput {
+  clientId: String!
+  status: ProjectStatusEnum
+}
+
+"""
+Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
+"""
 type ProjectType implements UserResourceTypeMixin & ProjectExportAssetTypeMixin {
   clientId: String!
   createdAt: DateTime!
@@ -1734,7 +1757,6 @@ input ProjectUpdateInput {
 
   """How many tasks each user is allowed to work on for this project"""
   maxTasksPerUser: Int
-  status: ProjectStatusEnum
 
   """Tutorial used for this project."""
   tutorial: ID
@@ -2322,6 +2344,8 @@ union UpdateOrganizationPayload = OrganizationTypeMutationResponseType | Operati
 union UpdateProcessedProjectPayload = ProjectTypeMutationResponseType | OperationInfo
 
 union UpdateProjectPayload = ProjectTypeMutationResponseType | OperationInfo
+
+union UpdateProjectStatusPayload = ProjectStatusTypeMutationResponseType | OperationInfo
 
 union UpdateTutorialPayload = TutorialTypeMutationResponseType | OperationInfo
 


### PR DESCRIPTION
## Changes
- add mutation for updating project status

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
