### PR TITLE
Breaking: Mutation for project and tutorial state change

### DIFF
--- a/apps/project/graphql/inputs/inputs.py
+++ b/apps/project/graphql/inputs/inputs.py
@@ -79,7 +79,6 @@ class ProjectUpdateInput(UserResourceTopLevelUpdateInputMixin):
     verification_number: strawberry.auto
     group_size: strawberry.auto
     max_tasks_per_user: strawberry.auto
-    status: strawberry.auto
     tutorial: strawberry.ID | None = strawberry.UNSET
     requesting_organization: strawberry.ID | None = strawberry.UNSET
     image: strawberry.ID | None = strawberry.UNSET
@@ -101,6 +100,11 @@ class ProcessedProjectUpdateInput(UserResourceTopLevelUpdateInputMixin):
     requesting_organization: strawberry.ID | None = strawberry.UNSET
     image: strawberry.ID | None = strawberry.UNSET
     team: strawberry.ID | None = strawberry.UNSET
+
+
+@strawberry_django.partial(Project)
+class ProjectStatusUpdateInput(UserResourceTopLevelUpdateInputMixin):
+    status: strawberry.auto
 
 
 # NOTE: Make sure this matches with the serializers ../serializers.py

--- a/apps/project/graphql/mutations.py
+++ b/apps/project/graphql/mutations.py
@@ -8,6 +8,7 @@ from apps.project.serializers import (
     ProcessedProjectSerializer,
     ProjectAssetSerializer,
     ProjectCreateSerializer,
+    ProjectStatusUpdateSerializer,
     ProjectUpdateSerializer,
 )
 from main.graphql.context import Info
@@ -20,9 +21,10 @@ from .inputs.inputs import (
     ProcessedProjectUpdateInput,
     ProjectAssetCreateInput,
     ProjectCreateInput,
+    ProjectStatusUpdateInput,
     ProjectUpdateInput,
 )
-from .types.types import OrganizationType, ProjectAssetType, ProjectType
+from .types.types import OrganizationType, ProjectAssetType, ProjectStatusType, ProjectType
 
 
 @strawberry.type
@@ -78,3 +80,13 @@ class Mutation:
     ) -> MutationResponseType[OrganizationType]:
         organization = await Organization.objects.aget(pk=pk)
         return await ModelMutation(OrganizationSerializer).handle_update_mutation(data, info, organization)
+
+    @strawberry_django.mutation(extensions=[IsAuthenticated()])
+    async def update_project_status(
+        self,
+        info: Info,
+        data: ProjectStatusUpdateInput,
+        pk: strawberry.ID,
+    ) -> MutationResponseType[ProjectStatusType]:
+        project = await Project.objects.aget(pk=pk)
+        return await ModelMutation(ProjectStatusUpdateSerializer).handle_update_mutation(data, info, project)

--- a/apps/project/graphql/mutations.py
+++ b/apps/project/graphql/mutations.py
@@ -24,7 +24,7 @@ from .inputs.inputs import (
     ProjectStatusUpdateInput,
     ProjectUpdateInput,
 )
-from .types.types import OrganizationType, ProjectAssetType, ProjectStatusType, ProjectType
+from .types.types import OrganizationType, ProjectAssetType, ProjectType
 
 
 @strawberry.type
@@ -87,6 +87,6 @@ class Mutation:
         info: Info,
         data: ProjectStatusUpdateInput,
         pk: strawberry.ID,
-    ) -> MutationResponseType[ProjectStatusType]:
+    ) -> MutationResponseType[ProjectType]:
         project = await Project.objects.aget(pk=pk)
         return await ModelMutation(ProjectStatusUpdateSerializer).handle_update_mutation(data, info, project)

--- a/apps/project/graphql/types/types.py
+++ b/apps/project/graphql/types/types.py
@@ -29,12 +29,6 @@ from .project_types.validate import ValidateProjectPropertyType
 from .project_types.validate_image import ValidateImageProjectPropertyType
 
 
-@strawberry_django.type(Project)
-class ProjectStatusType:
-    id: strawberry.ID
-    status: strawberry.auto
-
-
 # Organization
 @strawberry_django.type(Organization)
 class OrganizationType(UserResourceTypeMixin, ArchivableResourceTypeMixin):

--- a/apps/project/graphql/types/types.py
+++ b/apps/project/graphql/types/types.py
@@ -21,6 +21,8 @@ from .asset_types import AoiGeometryAssetPropertyType, ObjectImageAssetPropertyT
 # The tile server types are required by the following imports
 from .project_types import base  # noqa: F401  # isort: skip # type: ignore[reportUnusedImport]
 
+from apps.common.graphql.inputs import UserResourceTopLevelUpdateInputMixin
+
 from .project_types.compare import CompareProjectPropertyType
 from .project_types.completeness import CompletenessProjectPropertyType
 from .project_types.find import FindProjectPropertyType
@@ -31,6 +33,11 @@ from .project_types.validate_image import ValidateImageProjectPropertyType
 @strawberry_django.type(Project)
 class ProjectStatusType:
     id: strawberry.ID
+    status: strawberry.auto
+
+
+@strawberry_django.partial(Project)
+class ProjectStatusUpdateInput(UserResourceTopLevelUpdateInputMixin):
     status: strawberry.auto
 
 

--- a/apps/project/graphql/types/types.py
+++ b/apps/project/graphql/types/types.py
@@ -21,7 +21,6 @@ from .asset_types import AoiGeometryAssetPropertyType, ObjectImageAssetPropertyT
 # The tile server types are required by the following imports
 from .project_types import base  # noqa: F401  # isort: skip # type: ignore[reportUnusedImport]
 
-from apps.common.graphql.inputs import UserResourceTopLevelUpdateInputMixin
 
 from .project_types.compare import CompareProjectPropertyType
 from .project_types.completeness import CompletenessProjectPropertyType
@@ -33,11 +32,6 @@ from .project_types.validate_image import ValidateImageProjectPropertyType
 @strawberry_django.type(Project)
 class ProjectStatusType:
     id: strawberry.ID
-    status: strawberry.auto
-
-
-@strawberry_django.partial(Project)
-class ProjectStatusUpdateInput(UserResourceTopLevelUpdateInputMixin):
     status: strawberry.auto
 
 

--- a/apps/project/graphql/types/types.py
+++ b/apps/project/graphql/types/types.py
@@ -20,11 +20,18 @@ from .asset_types import AoiGeometryAssetPropertyType, ObjectImageAssetPropertyT
 # NOTE: We are importing base for side-effect
 # The tile server types are required by the following imports
 from .project_types import base  # noqa: F401  # isort: skip # type: ignore[reportUnusedImport]
+
 from .project_types.compare import CompareProjectPropertyType
 from .project_types.completeness import CompletenessProjectPropertyType
 from .project_types.find import FindProjectPropertyType
 from .project_types.validate import ValidateProjectPropertyType
 from .project_types.validate_image import ValidateImageProjectPropertyType
+
+
+@strawberry_django.type(Project)
+class ProjectStatusType:
+    id: strawberry.ID
+    status: strawberry.auto
 
 
 # Organization

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -31,15 +31,7 @@ VALID_PROJECT_STATUS_TRANSITIONS = set(
         (Project.Status.DRAFT, Project.Status.DISCARDED),
         (Project.Status.FAILED, Project.Status.MARKED_AS_READY),
         (Project.Status.FAILED, Project.Status.DISCARDED),
-    ],
-)
-
-
-VALID_PROCESSED_PROJECT_STATUS_TRANSITIONS = set(
-    [
         # NOTE: Transition from MARKED_AS_READY are updated by the system
-        # (Project.Status.MARKED_AS_READY, Project.Status.FAILED),
-        # (Project.Status.MARKED_AS_READY, Project.Status.READY),
         (Project.Status.READY, Project.Status.PUBLISHED),
         (Project.Status.READY, Project.Status.DISCARDED),
         (Project.Status.PUBLISHED, Project.Status.ARCHIVED),
@@ -102,7 +94,6 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
             "group_size",
             "max_tasks_per_user",
             "project_type_specifics",
-            "status",
             "tutorial",
             "team",
         )
@@ -113,25 +104,6 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
                 gettext("Cannot use archived team on a project."),
             )
         return team
-
-    def validate_status(self, new_status: Project.Status | int) -> Project.Status:
-        assert self.instance is not None, "Project does not exist."
-
-        if not isinstance(new_status, Project.Status):
-            new_status = Project.Status(new_status)
-
-        if (
-            self.instance.status_enum != new_status
-            and (self.instance.status_enum, new_status) not in VALID_PROJECT_STATUS_TRANSITIONS
-        ):
-            raise serializers.ValidationError(
-                gettext("Project status cannot be changed from %s to %s")
-                % (
-                    self.instance.status_enum.label,
-                    new_status.label,
-                ),
-            )
-        return new_status
 
     def validate_tutorial(self, tutorial: Tutorial | None) -> Tutorial | None:
         assert self.instance is not None
@@ -232,16 +204,6 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
         self._validate_project_type_specifics(attrs)
         return super().validate(attrs)
 
-    @typing.override
-    def update(self, instance: Project, validated_data: dict[str, typing.Any]) -> Project:  # type: ignore[reportIncompatibleMethodOverride]
-        old_status_enum = instance.status_enum
-        new_project = super().update(instance, validated_data)
-
-        if old_status_enum != Project.Status.MARKED_AS_READY and new_project.status_enum == Project.Status.MARKED_AS_READY:
-            transaction.on_commit(lambda: process_project_task.delay(new_project.pk))
-
-        return new_project
-
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
 class ProcessedProjectSerializer(UserResourceSerializer[Project]):
@@ -261,7 +223,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
             "additional_info_url",
             "description",
             "image",
-            "status",
             "tutorial",
             "team",
         )
@@ -272,22 +233,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
                 gettext("Cannot use archived team on a project."),
             )
         return team
-
-    def validate_status(self, new_status: Project.Status | int):
-        assert self.instance is not None, "Project does not exist."
-
-        if not isinstance(new_status, Project.Status):
-            new_status = Project.Status(new_status)
-
-        if (
-            self.instance.status_enum != new_status
-            and (self.instance.status_enum, new_status) not in VALID_PROCESSED_PROJECT_STATUS_TRANSITIONS
-        ):
-            raise serializers.ValidationError(
-                gettext("Project status cannot be changed from %s to %s")
-                % (self.instance.status_enum.label, new_status.label),
-            )
-        return new_status
 
     def validate_image(self, new_image: ProjectAsset | None):
         assert self.instance is not None
@@ -317,11 +262,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
         current_tutorial = self.instance.tutorial
         tutorial = new_tutorial or current_tutorial
 
-        if tutorial is None and attrs.get("status") == Project.Status.PUBLISHED:
-            raise serializers.ValidationError(
-                {"tutorial": gettext("Tutorial is required before publishing a project.")},
-            )
-
         # FIXME(susilnem): Check if we should use new_tutorial.status or new_status.status_enum
         if new_tutorial and new_tutorial != current_tutorial and new_tutorial.status_enum == Tutorial.Status.ARCHIVED:
             raise serializers.ValidationError(gettext("Cannot assign archived tutorial to the project."))
@@ -339,21 +279,6 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
 
         self._validate_tutorial(attrs)
         return super().validate(attrs)
-
-    @typing.override
-    def update(self, instance: Project, validated_data: dict[str, typing.Any]) -> Project:
-        old_status_enum = instance.status_enum
-        updated_project = super().update(instance, validated_data)
-
-        if (
-            old_status_enum != Project.Status.PUBLISHED and updated_project.status_enum == Project.Status.PUBLISHED
-        ) or old_status_enum == Project.Status.PUBLISHED:
-            updated_project.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-
-            # FIXME: We can call this on batch later as well or handle error scenario
-            transaction.on_commit(lambda: push_project_to_firebase.delay(updated_project.pk))
-
-        return updated_project
 
 
 # NOTE: Make sure this matches with the strawberry Input ./graphql/inputs.py
@@ -490,3 +415,59 @@ class OrganizationSerializer(UserResourceSerializer[Organization], ArchivableRes
         organization = super().update(instance, validated_data)
         FirebaseOrganizationPush(organization).trigger()
         return organization
+
+
+class ProjectStatusUpdateSerializer(UserResourceSerializer[Project]):
+    class Meta:  # type: ignore[reportIncompatibleVariableOverride]
+        model = Project
+        fields = ("status",)
+
+    def validate_status(self, new_status: Project.Status | int) -> Project.Status:
+        assert self.instance is not None, "Project does not exist."
+
+        if not isinstance(new_status, Project.Status):
+            new_status = Project.Status(new_status)
+
+        if (
+            self.instance.status_enum != new_status
+            and (self.instance.status_enum, new_status) not in VALID_PROJECT_STATUS_TRANSITIONS
+        ):
+            raise serializers.ValidationError(
+                gettext("Project status cannot be changed from %s to %s")
+                % (
+                    self.instance.status_enum.label,
+                    new_status.label,
+                ),
+            )
+
+        if new_status == Project.Status.PUBLISHED and not self.instance.tutorial:
+            raise serializers.ValidationError(
+                {"tutorial": gettext("Tutorial is required before publishing a project.")},
+            )
+        if new_status == Project.Status.MARKED_AS_READY and not self.instance.project_type_specifics:
+            raise serializers.ValidationError(
+                gettext("project_type_specifics is required when project status is %s") % (new_status.label),
+            )
+
+        return new_status
+
+    @typing.override
+    def update(self, instance: Project, validated_data: dict[str, typing.Any]) -> Project:  # type: ignore[reportIncompatibleMethodOverride]
+        old_status_enum = instance.status_enum
+        updated_project = super().update(instance, validated_data)
+
+        if (
+            old_status_enum != Project.Status.MARKED_AS_READY
+            and updated_project.status_enum == Project.Status.MARKED_AS_READY
+        ):
+            transaction.on_commit(lambda: process_project_task.delay(updated_project.pk))
+
+        if (
+            old_status_enum != Project.Status.PUBLISHED and updated_project.status_enum == Project.Status.PUBLISHED
+        ) or old_status_enum == Project.Status.PUBLISHED:
+            updated_project.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
+
+            # FIXME: We can call this on batch later as well or handle error scenario
+            transaction.on_commit(lambda: push_project_to_firebase.delay(updated_project.pk))
+
+        return updated_project

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -198,7 +198,7 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
     def validate(self, attrs: dict[str, typing.Any]):
         assert self.instance is not None
 
-        if self.instance.status_enum != Project.Status.DRAFT and self.instance.status_enum != Project.Status.FAILED:
+        if self.instance.status_enum not in [Project.Status.DRAFT, Project.Status.FAILED]:
             raise serializers.ValidationError(gettext("Cannot update project with status %s") % self.instance.status)
 
         self._validate_project_type_specifics(attrs)
@@ -272,6 +272,8 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
             raise serializers.ValidationError(
                 {"tutorial": gettext("Tutorial project type does not match the project type.")},
             )
+
+        # FIXME(tnagorra): We should also check if the parameters are the same. eg. zoomLevel, ...
 
     @typing.override
     def validate(self, attrs: dict[str, typing.Any]):
@@ -440,13 +442,13 @@ class ProjectStatusUpdateSerializer(UserResourceSerializer[Project]):
                 ),
             )
 
-        if new_status == Project.Status.PUBLISHED and not self.instance.tutorial:
-            raise serializers.ValidationError(
-                {"tutorial": gettext("Tutorial is required before publishing a project.")},
-            )
         if new_status == Project.Status.MARKED_AS_READY and not self.instance.project_type_specifics:
             raise serializers.ValidationError(
                 gettext("project_type_specifics is required when project status is %s") % (new_status.label),
+            )
+        if new_status == Project.Status.PUBLISHED and not self.instance.tutorial:
+            raise serializers.ValidationError(
+                {"tutorial": gettext("Tutorial is required before publishing a project.")},
             )
 
         return new_status
@@ -461,12 +463,10 @@ class ProjectStatusUpdateSerializer(UserResourceSerializer[Project]):
             and updated_project.status_enum == Project.Status.MARKED_AS_READY
         ):
             transaction.on_commit(lambda: process_project_task.delay(updated_project.pk))
-
-        if (
+        elif (
             old_status_enum != Project.Status.PUBLISHED and updated_project.status_enum == Project.Status.PUBLISHED
         ) or old_status_enum == Project.Status.PUBLISHED:
             updated_project.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-
             # FIXME: We can call this on batch later as well or handle error scenario
             transaction.on_commit(lambda: push_project_to_firebase.delay(updated_project.pk))
 

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -732,7 +732,7 @@ class TestProjectMutation(TestCase):
             "clientId": str(ULID()),
             "project": str(latest_project.pk),
         }
-        content = self._create_project_aoi_asset(project_asset_data, assert_errors=True)
+        content = self._create_project_aoi_asset(project_asset_data)
         resp_data = content["data"]["createProjectAsset"]
         assert resp_data["errors"] is None, content
         aoi_geometry_asset = resp_data["result"]
@@ -751,7 +751,7 @@ class TestProjectMutation(TestCase):
             "clientId": str(ULID()),
             "project": str(latest_project.pk),
         }
-        content = self._create_project_image_asset(project_asset_data, assert_errors=True)
+        content = self._create_project_image_asset(project_asset_data)
         resp_data = content["data"]["createProjectAsset"]
         assert resp_data["errors"] is None, content
         image_asset = resp_data["result"]
@@ -1083,7 +1083,7 @@ class TestProjectTypeMutation(TestCase):
             "project": project_id,
             "clientId": str(ULID()),
         }
-        content = self._create_project_aoi_asset(project_asset_data, assert_errors=True)
+        content = self._create_project_aoi_asset(project_asset_data)
         resp_data = content["data"]["createProjectAsset"]
         assert resp_data["errors"] is None, content
         aoi_geometry_asset = resp_data["result"]
@@ -1093,7 +1093,7 @@ class TestProjectTypeMutation(TestCase):
             "project": project_id,
             "clientId": str(ULID()),
         }
-        content = self._create_project_image_asset(project_asset_data, assert_errors=True)
+        content = self._create_project_image_asset(project_asset_data)
         resp_data = content["data"]["createProjectAsset"]
         assert resp_data["errors"] is None, content
         image_asset = resp_data["result"]
@@ -1352,7 +1352,7 @@ class TestProjectTypeMutation(TestCase):
             "clientId": project_client_id,
             "status": self.genum(Project.Status.PUBLISHED),
         }
-        content = self._update_project_status_mutation(project_id, project_data, assert_errors=True)
+        content = self._update_project_status_mutation(project_id, project_data)
 
         # Updating Processed Project:
         # Attaching tutorial

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -290,6 +290,29 @@ class Mutation:
           }
         }
     """
+    UPDATE_PROJECT_STATUS = """
+        mutation UpdateProjectStatus($pk: ID!, $data: ProjectStatusUpdateInput!) {
+          updateProjectStatus(pk: $pk, data: $data) {
+            ... on OperationInfo {
+              __typename
+              messages {
+                code
+                field
+                kind
+                message
+              }
+            }
+            ... on ProjectStatusTypeMutationResponseType {
+              errors
+              ok
+              result {
+                id
+                status
+              }
+            }
+          }
+        }
+    """
 
 
 class TestOrganizationMutation(TestCase):
@@ -490,6 +513,16 @@ class TestProjectMutation(TestCase):
                 **kwargs,
             )
 
+    def _update_project_status_mutation(self, pk: str, project_data: dict, **kwargs):
+        with self.captureOnCommitCallbacks(execute=True):
+            return update_project_query(
+                query_check_func=self.query_check,
+                query=Mutation.UPDATE_PROJECT_STATUS,
+                pk=pk,
+                project_data=project_data,
+                **kwargs,
+            )
+
     def test_project_create(self):
         project_data = {
             "clientId": str(ULID()),
@@ -682,13 +715,13 @@ class TestProjectMutation(TestCase):
             "clientId": proj.client_id,
             "status": self.genum(Project.Status.MARKED_AS_READY),
         }
-        content = self._update_project_mutation(str(latest_project.pk), project_data)
-        assert content["data"]["updateProject"]["errors"] == [
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] == [
             {
                 "array_errors": None,
                 "client_id": latest_project.client_id,
-                "field": "projectTypeSpecifics",
-                "messages": "Configuration not provided for Find",
+                "field": "status",
+                "messages": "project_type_specifics is required when project status is Marked as Ready",
                 "object_errors": None,
                 "pydantic_errors": None,
             },
@@ -814,8 +847,8 @@ class TestProjectMutation(TestCase):
             "clientId": proj.client_id,
             "status": self.genum(Project.Status.MARKED_AS_READY),
         }
-        content = self._update_project_mutation(str(latest_project.pk), project_data)
-        assert content["data"]["updateProject"]["errors"] is None
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] is None
 
         mock_requests.assert_called_once()
         mock_requests.assert_has_calls([call(latest_project.pk)])
@@ -843,29 +876,44 @@ class TestProjectMutation(TestCase):
             project=latest_project,
             status=Tutorial.Status.ARCHIVED,
         )
+
         project_data = {
             "clientId": proj.client_id,
-            "status": self.genum(Project.Status.PUBLISHED),
             "tutorial": self.gID(archived_tutorial.pk),
         }
         content = self._update_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProject"]["errors"] is not None
 
-        # Unarchiving Tutorial
-        archived_tutorial.status = Tutorial.Status.PUBLISHED
-        archived_tutorial.save(update_fields=["status"])
-
+        # Publish a project
+        # set unarchived tutorial to project before publishing a project
+        tutorial = TutorialFactory.create(
+            **self.user_resource_kwargs,
+            project=latest_project,
+            status=Tutorial.Status.PUBLISHED,
+        )
+        project_data = {
+            "clientId": proj.client_id,
+            "tutorial": tutorial.id,
+        }
         content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProcessedProject"]["errors"] is None, content
-
-        # Archiving tutorial
-        # Test Pass as archiving tutorial does not affect project on published projects
-        archived_tutorial.status = Tutorial.Status.ARCHIVED
-        archived_tutorial.save(update_fields=["status"])
+        latest_project.refresh_from_db()
 
         project_data = {
             "clientId": proj.client_id,
-            "tutorial": self.gID(archived_tutorial.pk),
+            "status": self.genum(Project.Status.PUBLISHED),
+        }
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] is None
+        latest_project.refresh_from_db()
+
+        # Archiving tutorial
+        # Test Pass as archiving tutorial does not affect project on published projects
+        tutorial.status = Tutorial.Status.ARCHIVED
+        tutorial.save(update_fields=["status"])
+        project_data = {
+            "clientId": proj.client_id,
+            "tutorial": self.gID(tutorial.pk),
         }
         content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
         assert content["data"]["updateProcessedProject"]["errors"] is None, content
@@ -875,9 +923,9 @@ class TestProjectMutation(TestCase):
             "clientId": proj.client_id,
             "status": self.genum(ProjectStatusEnum.ARCHIVED),
         }
-        content = self._update_processed_project_mutation(str(latest_project.pk), project_data)
-        assert content["data"]["updateProcessedProject"]["errors"] is None, content
-        assert content["data"]["updateProcessedProject"]["result"]["status"] == self.genum(ProjectStatusEnum.ARCHIVED)
+        content = self._update_project_status_mutation(str(latest_project.pk), project_data)
+        assert content["data"]["updateProjectStatus"]["errors"] is None, content
+        assert content["data"]["updateProjectStatus"]["result"]["status"] == self.genum(ProjectStatusEnum.ARCHIVED)
 
         # Updating project with archived team
         # fails as team is archived
@@ -989,6 +1037,16 @@ class TestProjectTypeMutation(TestCase):
             return update_project_query(
                 query_check_func=self.query_check,
                 query=Mutation.UPDATE_PROJECT,
+                pk=pk,
+                project_data=project_data,
+                **kwargs,
+            )
+
+    def _update_project_status_mutation(self, pk: str, project_data: dict, **kwargs):
+        with self.captureOnCommitCallbacks(execute=True):
+            return update_project_query(
+                query_check_func=self.query_check,
+                query=Mutation.UPDATE_PROJECT_STATUS,
                 pk=pk,
                 project_data=project_data,
                 **kwargs,
@@ -1146,11 +1204,12 @@ class TestProjectTypeMutation(TestCase):
             "clientId": project_client_id,
             "status": self.genum(Project.Status.MARKED_AS_READY),
         }
-        content = self._update_project_mutation(project_id, project_data)
-        resp_data = content["data"]["updateProject"]
+        content = self._update_project_status_mutation(project_id, project_data)
+        resp_data = content["data"]["updateProjectStatus"]
         assert resp_data["errors"] is None, content
         assert resp_data["result"]["status"] == self.genum(Project.Status.MARKED_AS_READY)
-        assert resp_data["result"]["processingStatus"] is None
+        latest_project.refresh_from_db()
+        assert latest_project.processing_status is None
 
         mock_requests.assert_called_once()
         mock_requests.assert_has_calls([call(int(project_id))])
@@ -1293,9 +1352,7 @@ class TestProjectTypeMutation(TestCase):
             "clientId": project_client_id,
             "status": self.genum(Project.Status.PUBLISHED),
         }
-        content = self._update_processed_project_mutation(project_id, project_data)
-        resp_data = content["data"]["updateProcessedProject"]
-        assert resp_data["errors"] is not None, content
+        content = self._update_project_status_mutation(project_id, project_data, assert_errors=True)
 
         # Updating Processed Project:
         # Attaching tutorial
@@ -1314,8 +1371,10 @@ class TestProjectTypeMutation(TestCase):
             "clientId": project_client_id,
             "status": self.genum(Project.Status.PUBLISHED),
         }
-        content = self._update_processed_project_mutation(project_id, project_data)
-        resp_data = content["data"]["updateProcessedProject"]
+        content = self._update_project_status_mutation(project_id, project_data)
+        resp_data = content["data"]["updateProjectStatus"]
         assert resp_data["errors"] is None, content
         assert resp_data["result"]["status"] == self.genum(Project.Status.PUBLISHED)
-        assert resp_data["result"]["processingStatus"] == self.genum(Project.ProcessingStatus.COMPLETED)
+
+        latest_project.refresh_from_db()
+        assert latest_project.processing_status == Project.ProcessingStatus.COMPLETED

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -302,7 +302,7 @@ class Mutation:
                 message
               }
             }
-            ... on ProjectStatusTypeMutationResponseType {
+            ... on ProjectTypeMutationResponseType {
               errors
               ok
               result {

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -290,7 +290,6 @@ class Mutation:
           }
         }
     """
-
     UPDATE_PROJECT_STATUS = """
         mutation UpdateProjectStatus($pk: ID!, $data: ProjectStatusUpdateInput!) {
           updateProjectStatus(pk: $pk, data: $data) {
@@ -1209,7 +1208,6 @@ class TestProjectTypeMutation(TestCase):
         resp_data = content["data"]["updateProjectStatus"]
         assert resp_data["errors"] is None, content
         assert resp_data["result"]["status"] == self.genum(Project.Status.MARKED_AS_READY)
-
         latest_project.refresh_from_db()
         assert latest_project.processing_status is None
 

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -290,6 +290,7 @@ class Mutation:
           }
         }
     """
+
     UPDATE_PROJECT_STATUS = """
         mutation UpdateProjectStatus($pk: ID!, $data: ProjectStatusUpdateInput!) {
           updateProjectStatus(pk: $pk, data: $data) {
@@ -1208,6 +1209,7 @@ class TestProjectTypeMutation(TestCase):
         resp_data = content["data"]["updateProjectStatus"]
         assert resp_data["errors"] is None, content
         assert resp_data["result"]["status"] == self.genum(Project.Status.MARKED_AS_READY)
+
         latest_project.refresh_from_db()
         assert latest_project.processing_status is None
 

--- a/apps/tutorial/graphql/inputs/inputs.py
+++ b/apps/tutorial/graphql/inputs/inputs.py
@@ -154,6 +154,10 @@ class TutorialAssetCreateInput(UserResourceCreateInputMixin):
 @strawberry_django.partial(Tutorial)
 class TutorialUpdateInput(UserResourceTopLevelUpdateInputMixin):
     name: strawberry.auto
-    status: strawberry.auto
     scenarios: list[TutorialScenarioPageInput] | None = strawberry.UNSET
     information_pages: list[TutorialInformationPageInput] | None = strawberry.UNSET
+
+
+@strawberry_django.partial(Tutorial)
+class TutorialStatusUpdateInput(UserResourceTopLevelUpdateInputMixin):
+    status: strawberry.auto

--- a/apps/tutorial/graphql/mutations.py
+++ b/apps/tutorial/graphql/mutations.py
@@ -21,7 +21,7 @@ from utils.graphql.mutations import ModelMutation
 from utils.graphql.types import CudInput, MutationResponseType
 
 from .inputs.inputs import TutorialAssetCreateInput, TutorialCreateInput, TutorialStatusUpdateInput, TutorialUpdateInput
-from .types.types import TutorialAssetType, TutorialStatusType, TutorialType
+from .types.types import TutorialAssetType, TutorialType
 
 
 @strawberry.type
@@ -96,6 +96,6 @@ class Mutation:
         info: Info,
         data: TutorialStatusUpdateInput,
         pk: strawberry.ID,
-    ) -> MutationResponseType[TutorialStatusType]:
+    ) -> MutationResponseType[TutorialType]:
         tutorial = await Tutorial.objects.aget(pk=pk)
         return await ModelMutation(TutorialStatusUpdateSerializer).handle_update_mutation(data, info, tutorial)

--- a/apps/tutorial/graphql/mutations.py
+++ b/apps/tutorial/graphql/mutations.py
@@ -9,14 +9,19 @@ from apps.tutorial.models import (
     TutorialScenarioPage,
     TutorialTask,
 )
-from apps.tutorial.serializers import TutorialAssetSerializer, TutorialCreateSerializer, TutorialUpdateSerializer
+from apps.tutorial.serializers import (
+    TutorialAssetSerializer,
+    TutorialCreateSerializer,
+    TutorialStatusUpdateSerializer,
+    TutorialUpdateSerializer,
+)
 from main.graphql.context import Info
 from utils.graphql.common import DataclassInstance
 from utils.graphql.mutations import ModelMutation
 from utils.graphql.types import CudInput, MutationResponseType
 
-from .inputs.inputs import TutorialAssetCreateInput, TutorialCreateInput, TutorialUpdateInput
-from .types.types import TutorialAssetType, TutorialType
+from .inputs.inputs import TutorialAssetCreateInput, TutorialCreateInput, TutorialStatusUpdateInput, TutorialUpdateInput
+from .types.types import TutorialAssetType, TutorialStatusType, TutorialType
 
 
 @strawberry.type
@@ -84,3 +89,13 @@ class Mutation:
         data: TutorialAssetCreateInput,
     ) -> MutationResponseType[TutorialAssetType]:
         return await ModelMutation(TutorialAssetSerializer).handle_create_mutation(data, info, None)
+
+    @strawberry_django.mutation(extensions=[IsAuthenticated()])
+    async def update_tutorial_status(
+        self,
+        info: Info,
+        data: TutorialStatusUpdateInput,
+        pk: strawberry.ID,
+    ) -> MutationResponseType[TutorialStatusType]:
+        tutorial = await Tutorial.objects.aget(pk=pk)
+        return await ModelMutation(TutorialStatusUpdateSerializer).handle_update_mutation(data, info, tutorial)

--- a/apps/tutorial/graphql/types/types.py
+++ b/apps/tutorial/graphql/types/types.py
@@ -145,3 +145,9 @@ class TutorialType(UserResourceTypeMixin):
     # The tests are failing randomly.
     scenarios: list[TutorialScenarioPageType]
     information_pages: list[TutorialInformationPageType]
+
+
+@strawberry_django.type(Tutorial)
+class TutorialStatusType:
+    id: strawberry.ID
+    status: strawberry.auto

--- a/apps/tutorial/graphql/types/types.py
+++ b/apps/tutorial/graphql/types/types.py
@@ -145,9 +145,3 @@ class TutorialType(UserResourceTypeMixin):
     # The tests are failing randomly.
     scenarios: list[TutorialScenarioPageType]
     information_pages: list[TutorialInformationPageType]
-
-
-@strawberry_django.type(Tutorial)
-class TutorialStatusType:
-    id: strawberry.ID
-    status: strawberry.auto

--- a/apps/tutorial/serializers.py
+++ b/apps/tutorial/serializers.py
@@ -332,29 +332,9 @@ class TutorialUpdateSerializer(UserResourceSerializer[Tutorial]):
         model = Tutorial
         fields = (
             "name",
-            "status",
             "information_pages",
             "scenarios",
         )
-
-    def validate_status(self, new_status: Tutorial.Status | int) -> Tutorial.Status:
-        assert self.instance is not None, "Tutorial does not exist."
-
-        if not isinstance(new_status, Tutorial.Status):
-            new_status = Tutorial.Status(new_status)
-
-        if (
-            self.instance.status_enum != new_status
-            and (self.instance.status_enum, new_status) not in VALID_TUTORIAL_STATUS_TRANSITIONS
-        ):
-            raise serializers.ValidationError(
-                gettext("Tutorial status cannot be changed from %s to %s")
-                % (
-                    self.instance.status_enum.label,
-                    new_status.label,
-                ),
-            )
-        return new_status
 
     @typing.override
     def create(self, validated_data: dict[typing.Any, typing.Any]):
@@ -395,7 +375,6 @@ class TutorialUpdateSerializer(UserResourceSerializer[Tutorial]):
         validated_data.pop("scenarios", None)
         validated_data.pop("information_pages", None)
 
-        old_status_enum = instance.status_enum
         updated_tutorial = super().update(instance, validated_data)
 
         scenario_qs = TutorialScenarioPage.objects.filter(
@@ -436,14 +415,6 @@ class TutorialUpdateSerializer(UserResourceSerializer[Tutorial]):
             )
             information_page_serializer.is_valid(raise_exception=True)
             information_page_serializer.save()
-
-        if (
-            old_status_enum != Tutorial.Status.PUBLISHED and updated_tutorial.status_enum == Tutorial.Status.PUBLISHED
-        ) or old_status_enum == Tutorial.Status.PUBLISHED:
-            updated_tutorial.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-
-            # FIXME: We can call this on batch later as well or handle error scenario
-            transaction.on_commit(lambda: push_tutorial_to_firebase.delay(updated_tutorial.pk))
 
         return updated_tutorial
 
@@ -524,11 +495,11 @@ class TutorialStatusUpdateSerializer(UserResourceSerializer[Tutorial]):
     def update(self, instance: Tutorial, validated_data: dict[typing.Any, typing.Any]):
         old_status_enum = instance.status_enum
         updated_tutorial = super().update(instance, validated_data)
+
         if (
             old_status_enum != Tutorial.Status.PUBLISHED and updated_tutorial.status_enum == Tutorial.Status.PUBLISHED
         ) or old_status_enum == Tutorial.Status.PUBLISHED:
             updated_tutorial.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-
             # FIXME: We can call this on batch later as well or handle error scenario
             transaction.on_commit(lambda: push_tutorial_to_firebase.delay(updated_tutorial.pk))
 

--- a/apps/tutorial/serializers.py
+++ b/apps/tutorial/serializers.py
@@ -492,3 +492,44 @@ class TutorialAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Tuto
                 typing.assert_never(input_type_enum)
 
         return attrs
+
+
+class TutorialStatusUpdateSerializer(UserResourceSerializer[Tutorial]):
+    class Meta:  # type: ignore[reportIncompatibleVariableOverride]
+        model = Tutorial
+        fields = ("status",)
+
+    @typing.override
+    def validate(self, attrs: dict[str, typing.Any]):
+        assert self.instance is not None, "Tutorial does not exist."
+        new_status = attrs.get("status")
+
+        if not isinstance(new_status, Tutorial.Status):
+            new_status = Tutorial.Status(new_status)
+
+        if (
+            self.instance.status_enum != new_status
+            and (self.instance.status_enum, new_status) not in VALID_TUTORIAL_STATUS_TRANSITIONS
+        ):
+            raise serializers.ValidationError(
+                gettext("Tutorial status cannot be changed from %s to %s")
+                % (
+                    self.instance.status_enum.label,
+                    new_status.label,
+                ),
+            )
+        return super().validate(attrs)
+
+    @typing.override
+    def update(self, instance: Tutorial, validated_data: dict[typing.Any, typing.Any]):
+        old_status_enum = instance.status_enum
+        updated_tutorial = super().update(instance, validated_data)
+        if (
+            old_status_enum != Tutorial.Status.PUBLISHED and updated_tutorial.status_enum == Tutorial.Status.PUBLISHED
+        ) or old_status_enum == Tutorial.Status.PUBLISHED:
+            updated_tutorial.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
+
+            # FIXME: We can call this on batch later as well or handle error scenario
+            transaction.on_commit(lambda: push_tutorial_to_firebase.delay(updated_tutorial.pk))
+
+        return updated_tutorial

--- a/apps/tutorial/tests/mutation_test.py
+++ b/apps/tutorial/tests/mutation_test.py
@@ -182,7 +182,7 @@ class Mutation:
                 message
               }
             }
-            ... on TutorialStatusTypeMutationResponseType {
+            ... on TutorialTypeMutationResponseType {
               errors
               ok
               result {

--- a/apps/tutorial/tests/mutation_test.py
+++ b/apps/tutorial/tests/mutation_test.py
@@ -170,6 +170,30 @@ class Mutation:
         }
     """
 
+    UPDATE_TUTORIAL_STATUS = """
+        mutation UpdateTutorialStatus($data: TutorialStatusUpdateInput!, $pk: ID!) {
+          updateTutorialStatus(data: $data, pk: $pk) {
+            ... on OperationInfo {
+              __typename
+              messages {
+                code
+                field
+                kind
+                message
+              }
+            }
+            ... on TutorialStatusTypeMutationResponseType {
+              errors
+              ok
+              result {
+                id
+                status
+                }
+              }
+            }
+        }
+    """
+
 
 class TestTutorialMutation(TestCase):
     @typing.override
@@ -208,6 +232,15 @@ class TestTutorialMutation(TestCase):
     def _update_tutorial_mutation(self, pk: str, tutorial_data: dict, **kwargs):
         return self.query_check(
             query=Mutation.UPDATE_TUTORIAL,
+            variables={
+                "data": tutorial_data,
+                "pk": pk,
+            },
+        )
+
+    def _update_tutorial_status_mutation(self, pk: str, tutorial_data: dict, **kwargs):
+        return self.query_check(
+            query=Mutation.UPDATE_TUTORIAL_STATUS,
             variables={
                 "data": tutorial_data,
                 "pk": pk,
@@ -406,6 +439,14 @@ class TestTutorialMutation(TestCase):
 
         latest_tutorial.refresh_from_db()
 
+        # Update tutorial status to publish
+        status_data = {
+            "clientId": latest_tutorial.client_id,
+            "status": self.genum(TutorialStatusEnum.PUBLISHED),
+        }
+        self._update_tutorial_status_mutation(latest_tutorial.pk, status_data)
+        latest_tutorial.refresh_from_db()
+
         assert resp_data == self.g_mutation_response(
             ok=True,
             result=dict(
@@ -470,9 +511,9 @@ class TestTutorialMutation(TestCase):
         tutorial_from_res = resp_data["result"]
         tutorial_from_res.pop("projectId")
         tutorial_from_res.pop("id")
+        tutorial_from_res.pop("status")
         tutorial_data = {
             **tutorial_from_res,
-            "status": self.genum(TutorialStatusEnum.PUBLISHED),
             "scenarios": [
                 {
                     "update": {
@@ -660,9 +701,9 @@ class TestTutorialMutation(TestCase):
                 "clientId": tutorial.client_id,
                 "status": self.genum(new_status),
             }
-            response = self._update_tutorial_mutation(str(tutorial.pk), data)
+            response = self._update_tutorial_status_mutation(str(tutorial.pk), data)
 
-            resp_data = response["data"]["updateTutorial"]
+            resp_data = response["data"]["updateTutorialStatus"]
             assert resp_data["errors"] is None, response
             tutorial.refresh_from_db()
             assert tutorial.status == new_status
@@ -681,9 +722,9 @@ class TestTutorialMutation(TestCase):
                 "clientId": tutorial.client_id,
                 "status": self.genum(new_status),
             }
-            response = self._update_tutorial_mutation(str(tutorial.pk), data)
+            response = self._update_tutorial_status_mutation(str(tutorial.pk), data)
 
-            resp_data = response["data"]["updateTutorial"]
+            resp_data = response["data"]["updateTutorialStatus"]
             assert resp_data["errors"] is not None, response
             assert "Tutorial status cannot be changed" in resp_data["errors"][0]["messages"], response
             tutorial.refresh_from_db()

--- a/schema.graphql
+++ b/schema.graphql
@@ -1540,20 +1540,6 @@ input ProjectStatusEnumFilterLookup {
 """
 Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
 """
-type ProjectStatusType {
-  id: ID!
-  status: ProjectStatusEnum!
-}
-
-type ProjectStatusTypeMutationResponseType {
-  ok: Boolean!
-  errors: CustomErrorType
-  result: ProjectStatusType
-}
-
-"""
-Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
-"""
 input ProjectStatusUpdateInput {
   clientId: String!
   status: ProjectStatusEnum
@@ -2244,20 +2230,6 @@ input TutorialStatusEnumFilterLookup {
 """
 Tutorial(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_push_status, firebase_last_pushed, project, name, status, firebase_id)
 """
-type TutorialStatusType {
-  id: ID!
-  status: TutorialStatusEnum!
-}
-
-type TutorialStatusTypeMutationResponseType {
-  ok: Boolean!
-  errors: CustomErrorType
-  result: TutorialStatusType
-}
-
-"""
-Tutorial(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_push_status, firebase_last_pushed, project, name, status, firebase_id)
-"""
 input TutorialStatusUpdateInput {
   clientId: String!
   status: TutorialStatusEnum
@@ -2367,11 +2339,11 @@ union UpdateProcessedProjectPayload = ProjectTypeMutationResponseType | Operatio
 
 union UpdateProjectPayload = ProjectTypeMutationResponseType | OperationInfo
 
-union UpdateProjectStatusPayload = ProjectStatusTypeMutationResponseType | OperationInfo
+union UpdateProjectStatusPayload = ProjectTypeMutationResponseType | OperationInfo
 
 union UpdateTutorialPayload = TutorialTypeMutationResponseType | OperationInfo
 
-union UpdateTutorialStatusPayload = TutorialStatusTypeMutationResponseType | OperationInfo
+union UpdateTutorialStatusPayload = TutorialTypeMutationResponseType | OperationInfo
 
 scalar Upload
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -847,6 +847,7 @@ type Mutation {
   createTutorial(data: TutorialCreateInput!): CreateTutorialPayload! @isAuthenticated
   updateTutorial(data: TutorialUpdateInput!, pk: ID!): UpdateTutorialPayload! @isAuthenticated
   createTutorialAsset(data: TutorialAssetCreateInput!): CreateTutorialAssetPayload! @isAuthenticated
+  updateTutorialStatus(data: TutorialStatusUpdateInput!, pk: ID!): UpdateTutorialStatusPayload! @isAuthenticated
   createContributorUserGroup(data: ContributorUserGroupCreateInput!): CreateContributorUserGroupPayload! @isAuthenticated
   updateContributorUserGroup(data: ContributorUserGroupUpdateInput!, pk: ID!): UpdateContributorUserGroupPayload! @isAuthenticated
 }
@@ -2241,6 +2242,28 @@ input TutorialStatusEnumFilterLookup {
 }
 
 """
+Tutorial(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_push_status, firebase_last_pushed, project, name, status, firebase_id)
+"""
+type TutorialStatusType {
+  id: ID!
+  status: TutorialStatusEnum!
+}
+
+type TutorialStatusTypeMutationResponseType {
+  ok: Boolean!
+  errors: CustomErrorType
+  result: TutorialStatusType
+}
+
+"""
+Tutorial(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_push_status, firebase_last_pushed, project, name, status, firebase_id)
+"""
+input TutorialStatusUpdateInput {
+  clientId: String!
+  status: TutorialStatusEnum
+}
+
+"""
 TutorialTask(id, client_id, created_at, modified_at, created_by, modified_by, scenario, reference, project_type_specifics)
 """
 input TutorialTaskCreateInput {
@@ -2332,7 +2355,6 @@ Tutorial(id, client_id, created_at, modified_at, created_by, modified_by, old_id
 input TutorialUpdateInput {
   clientId: String!
   name: String
-  status: TutorialStatusEnum
   scenarios: [TutorialScenarioPageInput!]
   informationPages: [TutorialInformationPageInput!]
 }
@@ -2348,6 +2370,8 @@ union UpdateProjectPayload = ProjectTypeMutationResponseType | OperationInfo
 union UpdateProjectStatusPayload = ProjectStatusTypeMutationResponseType | OperationInfo
 
 union UpdateTutorialPayload = TutorialTypeMutationResponseType | OperationInfo
+
+union UpdateTutorialStatusPayload = TutorialStatusTypeMutationResponseType | OperationInfo
 
 scalar Upload
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -842,6 +842,7 @@ type Mutation {
   createProjectAsset(data: ProjectAssetCreateInput!): CreateProjectAssetPayload! @isAuthenticated
   createOrganization(data: OrganizationCreateInput!): CreateOrganizationPayload! @isAuthenticated
   updateOrganization(data: OrganizationUpdateInput!, pk: ID!): UpdateOrganizationPayload! @isAuthenticated
+  updateProjectStatus(data: ProjectStatusUpdateInput!, pk: ID!): UpdateProjectStatusPayload! @isAuthenticated
   deleteTutorial: DeleteTutorialPayload! @isAuthenticated
   createTutorial(data: TutorialCreateInput!): CreateTutorialPayload! @isAuthenticated
   updateTutorial(data: TutorialUpdateInput!, pk: ID!): UpdateTutorialPayload! @isAuthenticated
@@ -1538,6 +1539,28 @@ input ProjectStatusEnumFilterLookup {
 """
 Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
 """
+type ProjectStatusType {
+  id: ID!
+  status: ProjectStatusEnum!
+}
+
+type ProjectStatusTypeMutationResponseType {
+  ok: Boolean!
+  errors: CustomErrorType
+  result: ProjectStatusType
+}
+
+"""
+Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
+"""
+input ProjectStatusUpdateInput {
+  clientId: String!
+  status: ProjectStatusEnum
+}
+
+"""
+Project(id, client_id, created_at, modified_at, created_by, modified_by, old_id, firebase_id, firebase_push_status, firebase_last_pushed, project_type, requesting_organization, topic, region, project_number, look_for, additional_info_url, description, image, tutorial, verification_number, group_size, max_tasks_per_user, project_type_specifics, project_type_specific_output, centroid, is_featured, status, processing_status, team, is_private, progress, required_results, result_count)
+"""
 type ProjectType implements UserResourceTypeMixin & ProjectExportAssetTypeMixin {
   clientId: String!
   createdAt: DateTime!
@@ -1734,7 +1757,6 @@ input ProjectUpdateInput {
 
   """How many tasks each user is allowed to work on for this project"""
   maxTasksPerUser: Int
-  status: ProjectStatusEnum
 
   """Tutorial used for this project."""
   tutorial: ID
@@ -2322,6 +2344,8 @@ union UpdateOrganizationPayload = OrganizationTypeMutationResponseType | Operati
 union UpdateProcessedProjectPayload = ProjectTypeMutationResponseType | OperationInfo
 
 union UpdateProjectPayload = ProjectTypeMutationResponseType | OperationInfo
+
+union UpdateProjectStatusPayload = ProjectStatusTypeMutationResponseType | OperationInfo
 
 union UpdateTutorialPayload = TutorialTypeMutationResponseType | OperationInfo
 

--- a/utils/graphql/drf.py
+++ b/utils/graphql/drf.py
@@ -57,7 +57,10 @@ class MutationCustomErrorType:
     def __getitem__(self, key: str):
         key = to_snake_case(key)
         if key in ("object_errors", "array_errors") and getattr(self, key):
-            return [dict(each) for each in getattr(self, key)]
+            # TODO(thenav56): Confirm if using str() is enough
+            if key == "object_errors":
+                return {each_key: str(each_data) for each_key, each_data in getattr(self, key).items()}
+            return [str(each) for each in getattr(self, key)]
         return getattr(self, key)
 
 


### PR DESCRIPTION
## Changes
- Add api to update tutorial status

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
