### PR TITLE
fix(firebase-auth): add firebase-auth url to allowed cors urls

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -464,7 +464,7 @@ CSRF_COOKIE_DOMAIN = env("CSRF_COOKIE_DOMAIN")
 CORS_ALLOWED_ORIGINS = MAPSWIPE_TRUSTED_ORIGINS
 
 CORS_ALLOW_CREDENTIALS = True
-CORS_URLS_REGEX = r"(^/media/.*$)|(^/graphql/$)|(^/health-check/$)"
+CORS_URLS_REGEX = r"(^/firebase-auth/.*$)|(^/media/.*$)|(^/graphql/$)|(^/health-check/$)"
 CORS_ALLOW_METHODS = (
     "DELETE",
     "GET",


### PR DESCRIPTION
## Changes

* add firebase-auth url to allowed cors urls

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations