### PR TITLE
Firebase: set firebase push status to PENDING before triggering

### DIFF
--- a/apps/common/firebase.py
+++ b/apps/common/firebase.py
@@ -21,9 +21,9 @@ class FirebasePush[T: FirebasePushResource, K: BaseModel](abc.ABC):
 
     def __init__(
         self,
-        obj_id: int,
+        obj: T,
     ):
-        self.obj_id = obj_id
+        self.obj = obj
 
     @classmethod
     def _inheritance_checks(cls):
@@ -56,17 +56,19 @@ class FirebasePush[T: FirebasePushResource, K: BaseModel](abc.ABC):
     @abc.abstractmethod
     def get_firebase_path(self, firebase_id: str, model: type[T]) -> str: ...
 
-    def push(self) -> None:
-        model_obj = self.model_class.objects.get(id=self.obj_id)
+    def trigger(self) -> None:
+        model_obj = self.obj
+        model_obj.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
+        self._push(model_obj)
 
-        # FIXME(tnagorra): The following fails because set firebase_push_status is not set on create/update
-        # if model_obj.firebase_push_status_enum != FirebasePushStatusEnum.PENDING:
-        #     logger.warning(
-        #         "Firebase push error: push is not required for %s",
-        #         model_obj._meta.label,
-        #         extra={"id": model_obj.pk},
-        #     )
-        #     return
+    def _push(self, model_obj: T) -> None:
+        if model_obj.firebase_push_status_enum != FirebasePushStatusEnum.PENDING:
+            logger.warning(
+                "Firebase push error: push is not required for %s",
+                model_obj._meta.label,
+                extra={"id": model_obj.pk},
+            )
+            return
 
         model_obj.update_firebase_push_status(FirebasePushStatusEnum.PROCESSING)
 

--- a/apps/common/models.py
+++ b/apps/common/models.py
@@ -137,8 +137,6 @@ class FirebasePushResource(Model):
         help_text=gettext_lazy("The latest time when resource was pushed to firebase"),
     )
 
-    # FIXME(tnagorra): Override create and update to set FirebasePushStatusEnum.PENDING
-
     @property
     def firebase_push_status_enum(self):
         if self.firebase_push_status:

--- a/apps/contributor/admin.py
+++ b/apps/contributor/admin.py
@@ -7,6 +7,7 @@ from django.utils.html import format_html
 from djangoql.admin import DjangoQLSearchMixin
 
 from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin
+from apps.common.models import FirebasePushStatusEnum
 
 from .firebase import FirebaseContributorTeam, FirebaseContributorUser
 from .models import ContributorTeam, ContributorUser, ContributorUserGroup, ContributorUserGroupMembership
@@ -42,6 +43,7 @@ class ContributorUserAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
     @typing.override
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)  # type: ignore[reportAttributeAccessIssue]
+        obj.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
         transaction.on_commit(lambda: FirebaseContributorUser(obj.id).push())
 
 
@@ -64,6 +66,7 @@ class ContributorTeamAdmin(ArchivableResourceAdmin, DjangoQLSearchMixin, Firebas
     @typing.override
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)  # type: ignore[reportAttributeAccessIssue]
+        obj.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
         transaction.on_commit(lambda: FirebaseContributorTeam(obj.id).push())
 
     def view_team_members(self, obj):

--- a/apps/contributor/admin.py
+++ b/apps/contributor/admin.py
@@ -1,13 +1,11 @@
 import typing
 
 from django.contrib import admin
-from django.db import transaction
 from django.urls import reverse
 from django.utils.html import format_html
 from djangoql.admin import DjangoQLSearchMixin
 
 from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin
-from apps.common.models import FirebasePushStatusEnum
 
 from .firebase import FirebaseContributorTeam, FirebaseContributorUser
 from .models import ContributorTeam, ContributorUser, ContributorUserGroup, ContributorUserGroupMembership
@@ -43,8 +41,7 @@ class ContributorUserAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
     @typing.override
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)  # type: ignore[reportAttributeAccessIssue]
-        obj.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-        transaction.on_commit(lambda: FirebaseContributorUser(obj.id).push())
+        FirebaseContributorUser(obj).trigger()
 
 
 @admin.register(ContributorUserGroup)
@@ -66,8 +63,7 @@ class ContributorTeamAdmin(ArchivableResourceAdmin, DjangoQLSearchMixin, Firebas
     @typing.override
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)  # type: ignore[reportAttributeAccessIssue]
-        obj.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-        transaction.on_commit(lambda: FirebaseContributorTeam(obj.id).push())
+        FirebaseContributorTeam(obj).trigger()
 
     def view_team_members(self, obj):
         url = reverse("admin:contributor_contributoruser_changelist") + f"?team__id__exact={obj.id}"

--- a/apps/contributor/management/commands/create_contributor_users.py
+++ b/apps/contributor/management/commands/create_contributor_users.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def push_team_to_firebase(team: ContributorTeam):
+    team.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
     fb_reference = Config.FIREBASE_HELPER.ref(
         Config.FirebaseKeys.contributor_team(team.firebase_id),
     )
@@ -30,9 +31,11 @@ def push_team_to_firebase(team: ContributorTeam):
     fb_reference.set(
         value=firebase_utils.serialize(contributor_team_data),
     )
+    team.update_firebase_push_status(FirebasePushStatusEnum.SUCCESS)
 
 
 def push_team_member_to_firebase(member: ContributorUser):
+    member.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
     fb_reference = Config.FIREBASE_HELPER.ref(
         Config.FirebaseKeys.contributor_user(member.firebase_id),
     )
@@ -47,6 +50,7 @@ def push_team_member_to_firebase(member: ContributorUser):
     fb_reference.set(
         value=firebase_utils.serialize(team_member_data),
     )
+    member.update_firebase_push_status(FirebasePushStatusEnum.SUCCESS)
 
 
 class Command(BaseCommand):
@@ -66,7 +70,6 @@ class Command(BaseCommand):
         )
         team_a, team_b = ContributorTeamFactory.create_batch(2, **user_resources)
         for team in [team_a, team_b]:
-            team.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
             push_team_to_firebase(team)
 
         team_a_members = ContributorUserFactory.create_batch(5, team=team_a, firebase_last_pushed=timezone.now())
@@ -74,7 +77,6 @@ class Command(BaseCommand):
         no_team_members = ContributorUserFactory.create_batch(5, firebase_last_pushed=timezone.now())
         for team_members in [team_a_members, team_b_members, no_team_members]:
             for member in team_members:
-                member.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
                 push_team_member_to_firebase(member)
 
         logger.info("Contributor users created successfully")

--- a/apps/contributor/management/commands/create_contributor_users.py
+++ b/apps/contributor/management/commands/create_contributor_users.py
@@ -9,6 +9,7 @@ from pyfirebase_mapswipe import extended_models as firebase_extended_models
 from pyfirebase_mapswipe import models as firebase_models
 from pyfirebase_mapswipe import utils as firebase_utils
 
+from apps.common.models import FirebasePushStatusEnum
 from apps.contributor.factories import ContributorTeamFactory, ContributorUserFactory
 from apps.contributor.models import ContributorTeam, ContributorUser
 from apps.user.factories import UserFactory
@@ -65,6 +66,7 @@ class Command(BaseCommand):
         )
         team_a, team_b = ContributorTeamFactory.create_batch(2, **user_resources)
         for team in [team_a, team_b]:
+            team.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
             push_team_to_firebase(team)
 
         team_a_members = ContributorUserFactory.create_batch(5, team=team_a, firebase_last_pushed=timezone.now())
@@ -72,6 +74,7 @@ class Command(BaseCommand):
         no_team_members = ContributorUserFactory.create_batch(5, firebase_last_pushed=timezone.now())
         for team_members in [team_a_members, team_b_members, no_team_members]:
             for member in team_members:
+                member.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
                 push_team_member_to_firebase(member)
 
         logger.info("Contributor users created successfully")

--- a/apps/contributor/serializers.py
+++ b/apps/contributor/serializers.py
@@ -1,8 +1,5 @@
 import typing
 
-from django.db import transaction
-
-from apps.common.models import FirebasePushStatusEnum
 from apps.common.serializers import ArchivableResourceSerializer, UserResourceSerializer
 from apps.contributor.firebase import FirebaseContributorUserGroup
 
@@ -24,13 +21,11 @@ class ContributorUserGroupSerializer(
     @typing.override
     def create(self, validated_data: dict[str, typing.Any]) -> ContributorUserGroup:
         user_group = super().create(validated_data)
-        user_group.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-        transaction.on_commit(lambda: FirebaseContributorUserGroup(user_group.id).push())
+        FirebaseContributorUserGroup(user_group).trigger()
         return user_group
 
     @typing.override
     def update(self, instance: ContributorUserGroup, validated_data: dict[typing.Any, typing.Any]):
         user_group = super().update(instance, validated_data)
-        user_group.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-        transaction.on_commit(lambda: FirebaseContributorUserGroup(user_group.id).push())
+        FirebaseContributorUserGroup(user_group).trigger()
         return user_group

--- a/apps/contributor/serializers.py
+++ b/apps/contributor/serializers.py
@@ -2,6 +2,7 @@ import typing
 
 from django.db import transaction
 
+from apps.common.models import FirebasePushStatusEnum
 from apps.common.serializers import ArchivableResourceSerializer, UserResourceSerializer
 from apps.contributor.firebase import FirebaseContributorUserGroup
 
@@ -23,11 +24,13 @@ class ContributorUserGroupSerializer(
     @typing.override
     def create(self, validated_data: dict[str, typing.Any]) -> ContributorUserGroup:
         user_group = super().create(validated_data)
+        user_group.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
         transaction.on_commit(lambda: FirebaseContributorUserGroup(user_group.id).push())
         return user_group
 
     @typing.override
     def update(self, instance: ContributorUserGroup, validated_data: dict[typing.Any, typing.Any]):
         user_group = super().update(instance, validated_data)
+        user_group.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
         transaction.on_commit(lambda: FirebaseContributorUserGroup(user_group.id).push())
         return user_group

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -482,11 +482,13 @@ class OrganizationSerializer(UserResourceSerializer[Organization], ArchivableRes
     @typing.override
     def create(self, validated_data: dict[str, typing.Any]) -> Organization:
         organization = super().create(validated_data)
+        organization.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
         transaction.on_commit(lambda: FirebaseOrganizationPush(organization.pk).push())
         return organization
 
     @typing.override
     def update(self, instance: Organization, validated_data: dict[typing.Any, typing.Any]):
         organization = super().update(instance, validated_data)
+        organization.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
         transaction.on_commit(lambda: FirebaseOrganizationPush(organization.pk).push())
         return organization

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -482,13 +482,11 @@ class OrganizationSerializer(UserResourceSerializer[Organization], ArchivableRes
     @typing.override
     def create(self, validated_data: dict[str, typing.Any]) -> Organization:
         organization = super().create(validated_data)
-        organization.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-        transaction.on_commit(lambda: FirebaseOrganizationPush(organization.pk).push())
+        FirebaseOrganizationPush(organization).trigger()
         return organization
 
     @typing.override
     def update(self, instance: Organization, validated_data: dict[typing.Any, typing.Any]):
         organization = super().update(instance, validated_data)
-        organization.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
-        transaction.on_commit(lambda: FirebaseOrganizationPush(organization.pk).push())
+        FirebaseOrganizationPush(organization).trigger()
         return organization


### PR DESCRIPTION
## Changes
- set firebase push status to PENDING before triggering firebase push.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
