### PR TITLE
Separate max time spend percentile

### DIFF
--- a/apps/community_dashboard/tests/query_test.py
+++ b/apps/community_dashboard/tests/query_test.py
@@ -27,6 +27,9 @@ from project_types.base.project import BaseProject as BaseProjectHandler
 class FakeBaseProjectHandler(typing.NamedTuple):
     project: Project
 
+    def get_max_time_spend_percentile(self) -> float:
+        return 11.2  # NOTE: value for COMPARE project_type
+
 
 # TODO(thenav56): Validate data accuracy
 

--- a/project_types/base/project.py
+++ b/project_types/base/project.py
@@ -22,7 +22,6 @@ from apps.project.models import (
     ProjectStatusEnum,
     ProjectTask,
     ProjectTaskGroup,
-    ProjectTypeEnum,
 )
 from main.bulk_managers import FirebaseBulkManager
 from main.config import Config
@@ -33,34 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 class InvalidProjectPushException(Exception): ...
-
-
-# FIXME(tnagorra): We should define these in each project type class
-def get_max_time_spend_percentile(project_type: ProjectTypeEnum) -> float:
-    """
-    Factor calculated by @Hagellach37
-    For defining the threshold for outliers using `95_percent`
-
-    |project_type|median|95_percent|avg|
-    |------------|------|----------|---|
-    |1|00:00:00.208768|00:00:01.398161|00:00:28.951521|
-    |2|00:00:01.330297|00:00:06.076814|00:00:03.481192|
-    |3|00:00:02.092967|00:00:11.271081|00:00:06.045881|
-    """
-    match project_type:
-        case ProjectTypeEnum.FIND:
-            return 1.4
-        case ProjectTypeEnum.COMPLETENESS:
-            return 1.4
-        case ProjectTypeEnum.COMPARE:
-            return 11.2
-        case ProjectTypeEnum.VALIDATE:
-            return 6.1
-        case ProjectTypeEnum.VALIDATE_IMAGE:
-            # FIXME(tnagorra): We need to update this value once the feature is deployed
-            return 6.1
-        # case ProjectTypeEnum.STREET:
-        #     return 65
 
 
 class BaseProjectProperty(BaseModel, ABC): ...
@@ -137,9 +108,7 @@ class BaseProject[
         # NOTE: After number_of_tasks is calculated
         project_task_groups_qs.update(
             required_count=models.F("number_of_tasks") * self.project.verification_number,
-            time_spent_max_allowed=(
-                models.F("number_of_tasks") * get_max_time_spend_percentile(self.project.project_type_enum)
-            ),
+            time_spent_max_allowed=(models.F("number_of_tasks") * self.get_max_time_spend_percentile()),
         )
 
         self.project.required_results = (
@@ -148,6 +117,20 @@ class BaseProject[
             .aggregate(required_results=models.Sum("required_count"))
         )["required_results"]
         self.project.save(update_fields=(["required_results"]))
+
+    @abstractmethod
+    def get_max_time_spend_percentile(self) -> float:
+        """
+        Factor calculated by @Hagellach37
+        For defining the threshold for outliers using `95_percent`
+
+        |project_type|median|95_percent|avg|
+        |------------|------|----------|---|
+        |1|00:00:00.208768|00:00:01.398161|00:00:28.951521|
+        |2|00:00:01.330297|00:00:06.076814|00:00:03.481192|
+        |3|00:00:02.092967|00:00:11.271081|00:00:06.045881|
+        """
+        ...
 
     @abstractmethod
     def post_create_groups(self): ...

--- a/project_types/tile_map_service/compare/project.py
+++ b/project_types/tile_map_service/compare/project.py
@@ -33,6 +33,10 @@ class CompareProject(
         if typing.TYPE_CHECKING:
             assert project.project_type == ProjectTypeEnum.COMPARE, f"{type(self)} is defined for COMPARE"
 
+    @typing.override
+    def get_max_time_spend_percentile(self) -> float:
+        return 11.2
+
     # FIREBASE
 
     @typing.override

--- a/project_types/tile_map_service/completeness/project.py
+++ b/project_types/tile_map_service/completeness/project.py
@@ -102,6 +102,10 @@ class CompletenessProject(
             assert project.project_type == ProjectTypeEnum.COMPLETENESS, f"{type(self)} is defined for COMPLETENESS"
 
     @typing.override
+    def get_max_time_spend_percentile(self) -> float:
+        return 1.4
+
+    @typing.override
     def get_project_specifics_for_firebase(self):
         tsp = self.project_type_specifics.tile_server_property
         tsp_overlay = self.project_type_specifics.overlay_tile_server_property

--- a/project_types/tile_map_service/find/project.py
+++ b/project_types/tile_map_service/find/project.py
@@ -32,6 +32,10 @@ class FindProject(
             assert project.project_type == ProjectTypeEnum.FIND, f"{type(self)} is defined for FIND"
 
     @typing.override
+    def get_max_time_spend_percentile(self) -> float:
+        return 1.4
+
+    @typing.override
     def get_project_specifics_for_firebase(self):
         tsp = self.project_type_specifics.tile_server_property
         return firebase_models.FbProjectFindCreateOnlyInput(

--- a/project_types/validate/project.py
+++ b/project_types/validate/project.py
@@ -354,6 +354,10 @@ class ValidateProject(
         self.project.project_type_specific_output = asset
         self.project.save(update_fields=("project_type_specific_output",))
 
+    @typing.override
+    def get_max_time_spend_percentile(self) -> float:
+        return 6.1
+
     # FIREBASE
 
     @typing.override

--- a/project_types/validate_image/project.py
+++ b/project_types/validate_image/project.py
@@ -214,6 +214,10 @@ class ValidateImageProject(
     @typing.override
     def post_create_groups(self): ...
 
+    @typing.override
+    def get_max_time_spend_percentile(self) -> float:
+        return 6.1
+
     # FIREBASE
 
     @typing.override


### PR DESCRIPTION
## Changes

* Separate max time spend percentile

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
- [X] permission checks (tests here too)
- [X] translations
