### PR TITLE
Allow plain text in aoi validation

### DIFF
--- a/apps/common/models.py
+++ b/apps/common/models.py
@@ -187,6 +187,8 @@ class AssetMimetypeEnum(models.IntegerChoices):
 
     CSV = 400, "text/csv"
 
+    PLAINTEXT = 500, "text/plain"
+
     @classmethod
     def get_display(cls, value: typing.Self | int) -> str:
         if value in cls:

--- a/apps/common/serializers.py
+++ b/apps/common/serializers.py
@@ -207,7 +207,7 @@ class CommonAssetSerializer(serializers.ModelSerializer[CommonAsset]):
             return
 
         file_content.seek(0)
-        file_head = file_content.read(2048)
+        file_head = file_content.read(4096)
         file_content.seek(0)
 
         mimetype = magic.from_buffer(file_head, mime=True)

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -305,8 +305,8 @@ class ProjectAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Proje
         if not file:
             raise ValidationError("Required field file is not provided.")
 
-        if not mimetype or mimetype not in [AssetMimetypeEnum.JSON, AssetMimetypeEnum.GEOJSON]:
-            raise ValidationError("Mimetype is should either be a JSON or GeoJSON")
+        if not mimetype or mimetype not in [AssetMimetypeEnum.JSON, AssetMimetypeEnum.GEOJSON, AssetMimetypeEnum.PLAINTEXT]:
+            raise ValidationError("Mimetype is should either be a Text, JSON or GeoJSON")
 
         try:
             geojson_data = json.load(file)

--- a/schema.graphql
+++ b/schema.graphql
@@ -143,6 +143,7 @@ enum AssetMimetypeEnum {
   IMAGE_GIF
   GZIP
   CSV
+  PLAINTEXT
 }
 
 input AssetMimetypeEnumFilterLookup {


### PR DESCRIPTION
## Changes

* Add plaintext enum
* Allow plaintext mimetype
* increase read buffer to 4096.

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
- [X] permission checks (tests here too)
- [X] translations
