### PR TITLE
Update usergroup archived at value before syncing to firebase

### DIFF
--- a/apps/contributor/firebase/push.py
+++ b/apps/contributor/firebase/push.py
@@ -95,7 +95,7 @@ class FirebaseContributorUserGroup(FirebasePush[ContributorUserGroup, firebase_e
             nameKey=model_obj.name.lower().strip(),
             users=None,
             archivedBy=model_obj.modified_by.firebase_id or str(model_obj.modified_by_id) if model_obj.is_archived else None,
-            archivedAt=int(model_obj.modified_at.timestamp()) if model_obj.is_archived else None,
+            archivedAt=int(model_obj.modified_at.timestamp() * 1000) if model_obj.is_archived else None,
         )
 
         fb_reference.set(
@@ -118,7 +118,7 @@ class FirebaseContributorUserGroup(FirebasePush[ContributorUserGroup, firebase_e
                     archivedBy=model_obj.modified_by.firebase_id or str(model_obj.modified_by_id)
                     if model_obj.is_archived
                     else None,
-                    archivedAt=int(model_obj.modified_at.timestamp()) if model_obj.is_archived else None,
+                    archivedAt=int(model_obj.modified_at.timestamp() * 1000) if model_obj.is_archived else None,
                 ),
             ),
         )

--- a/apps/contributor/firebase/utils.py
+++ b/apps/contributor/firebase/utils.py
@@ -2,7 +2,7 @@ import logging
 import typing
 
 from firebase_admin.db import Reference
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from main.config import Config
 
@@ -34,6 +34,13 @@ def get_list_of_items_from_firebase[T: BaseModel](
             if not item:
                 raise LookupError(f"Item with key {key} not found")
             item_obj = model.model_validate(item)
+
+            class RelaxedModel(model):
+                model_config = ConfigDict(extra="ignore")
+
+            # NOTE: we want to ignore extra fields from firebase
+            item_obj = RelaxedModel.model_validate(item)
+            item_obj = model.model_validate(item_obj)
         except ValidationError:
             errored_count += 1
             logger.warning("Validation failed for item from firebase: %s", key)

--- a/apps/contributor/firebase/utils.py
+++ b/apps/contributor/firebase/utils.py
@@ -20,7 +20,7 @@ def get_list_of_items_from_firebase[T: BaseModel](
 
     # Check if there are any updates
     if not keys:
-        logger.info("Found no items on firebase for %s", items_key)
+        logger.info("%s items not found on firebase at %s", model.__name__, items_key)
         return ([], 0, items_ref)
 
     all_keys = keys.keys()
@@ -32,8 +32,7 @@ def get_list_of_items_from_firebase[T: BaseModel](
         try:
             item = typing.cast("dict[str, typing.Any] | None", item_ref.get())
             if not item:
-                raise LookupError(f"Item with key {key} not found")
-            item_obj = model.model_validate(item)
+                raise LookupError(f"{model.__name__} item with key {key} not found")
 
             class RelaxedModel(model):
                 model_config = ConfigDict(extra="ignore")
@@ -43,11 +42,12 @@ def get_list_of_items_from_firebase[T: BaseModel](
             item_obj = model.model_validate(item_obj)
         except ValidationError:
             errored_count += 1
-            logger.warning("Validation failed for item from firebase: %s", key)
+            # FIXME: Do we need to show actual error?
+            logger.warning("Validation failed for %s item from firebase: %s", model.__name__, key)
             continue
         except LookupError:
             errored_count += 1
-            logger.warning("Item not found in firebase: %s", key)
+            logger.warning("%s item not found in firebase: %s", model.__name__, key)
             continue
 
         items_to_pull.append((key, item_obj))

--- a/apps/contributor/management/commands/create_contributor_users.py
+++ b/apps/contributor/management/commands/create_contributor_users.py
@@ -46,6 +46,10 @@ def push_team_member_to_firebase(member: ContributorUser):
         usernameKey=member.username.lower().strip(),
         teamId=member.team.firebase_id if member.team else None,
         created=timezone.now(),
+        lastAppUse=timezone.now(),
+        taskContributionCount=0,
+        groupContributionCount=0,
+        projectContributionCount=0,
     )
     fb_reference.set(
         value=firebase_utils.serialize(team_member_data),

--- a/apps/contributor/tests/firebase_test.py
+++ b/apps/contributor/tests/firebase_test.py
@@ -105,6 +105,91 @@ class TestContributorFirebase(TestCase):
         fb_reference = Config.FIREBASE_HELPER.ref(Config.FirebaseKeys.contributor_user_updates())
         return fb_reference.get()
 
+    def test_users_pull_from_firebase_raw(self):
+        users: list[tuple[str, dict[str, typing.Any]]] = [
+            (
+                "1a6tkl67iua5zpf0xdfUerNLTYi1",
+                {
+                    "created": "2025-08-25T04:49:49.082Z",
+                    "groupContributionCount": 0,
+                    "projectContributionCount": 0,
+                    "taskContributionCount": 0,
+                    "username": "barsha",
+                },
+            ),
+            (
+                "3jy9bxKxUsY6j3rvYMRm2zYqhxu1",
+                {
+                    "created": "2025-08-25T04:50:45.595Z",
+                    "groupContributionCount": 0,
+                    "lastAppUse": "2025-08-25T04:51:23.269Z",
+                    "projectContributionCount": 0,
+                    "taskContributionCount": 0,
+                    "username": "barkha",
+                },
+            ),
+            (
+                "68uL6PpiQoWrmny0HbgUBUcyDjf2",
+                {
+                    "created": "2025-08-21T09:55:02.659Z",
+                    "groupContributionCount": 0,
+                    "lastAppUse": "2025-08-25T06:11:35.851Z",
+                    "projectContributionCount": 0,
+                    "taskContributionCount": 0,
+                    "username": "ramesh",
+                    "usernameKey": "ramesh",
+                },
+            ),
+            (
+                "6PF7qylcJFSwPT1NVP2h7ZRf2r32",
+                {
+                    "contributions": {
+                        "01K21YDVN8DQHEV7RJRGXHB92H": {
+                            "g546": True,
+                            "g551": True,
+                            "taskContributionCount": 22,
+                        },
+                    },
+                    "created": "2025-08-07T10:33:20.022Z",
+                    "groupContributionCount": 2,
+                    "lastAppUse": "2025-08-08T06:17:31.873Z",
+                    "projectContributionCount": 1,
+                    "taskContributionCount": 22,
+                    "username": "hari",
+                    "usernameKey": "hari",
+                },
+            ),
+            (
+                "OFDRXP2WkYMwHW7gGsCqXcUhhel1",
+                {
+                    "contributions": {
+                        "01K3G7B2Y45S8F9V32KHZQCATW": {
+                            "g101": True,
+                            "taskContributionCount": 24,
+                        },
+                        "01K42775Q4VC01X0BS504JMD0S": {
+                            "g108": True,
+                            "taskContributionCount": 132,
+                        },
+                    },
+                    "created": "2025-08-27T04:15:16.179Z",
+                    "groupContributionCount": 5,
+                    "lastAppUse": "2025-09-01T08:51:36.920Z",
+                    "projectContributionCount": 5,
+                    "taskContributionCount": 227,
+                    "username": "gita",
+                },
+            ),
+        ]
+        for key, user in users:
+            user_ref = Config.FIREBASE_HELPER.ref(Config.FirebaseKeys.contributor_user(key))
+            user_ref.set(value=user)
+            user_update_ref = Config.FIREBASE_HELPER.ref(Config.FirebaseKeys.contributor_user_update(key))
+            user_update_ref.set(value=user)
+
+        pull_users_from_firebase()
+        assert ContributorUser.objects.all().count() == 5
+
     def test_users_pull_from_firebase(self):
         # Firebase Users:           Ram, Laxman, Shyam, Gita, Sita
         # Firebase User Updates:    Ram(u), Laxman(u), Gita(c), Sita(c), Hari(?), Ankit (?)

--- a/apps/contributor/tests/firebase_test.py
+++ b/apps/contributor/tests/firebase_test.py
@@ -46,6 +46,10 @@ class TestContributorFirebase(TestCase):
             usernameKey=username.lower().strip(),
             teamId=member.team.firebase_id if member.team else None,
             created=timezone.now(),
+            lastAppUse=timezone.now(),
+            taskContributionCount=0,
+            groupContributionCount=0,
+            projectContributionCount=0,
         )
         fb_reference.set(
             value=firebase_utils.serialize(team_member_data),

--- a/main/config.py
+++ b/main/config.py
@@ -110,6 +110,10 @@ class Config:
             return "/v2/updates/users"
 
         @staticmethod
+        def contributor_user_update(user_id: str):
+            return f"/v2/updates/users/{user_id}"
+
+        @staticmethod
         def contributor_user_group(group_id: str):
             return f"/v2/userGroups/{group_id}"
 


### PR DESCRIPTION
## Depends on
- https://github.com/mapswipe/mapswipe-firebase/pull/39

## Changes

* Fix issue with getting user data from firebase
* Make logs more verbose when pulling data for user and usergroup membership
* Fix "archived at" value when pushing usergroup data to firebase

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
