### PR TITLE
Fix task name for firebase user pull

### DIFF
--- a/main/cronjobs.py
+++ b/main/cronjobs.py
@@ -51,7 +51,7 @@ SCHEDULES: dict[str, CronJob] = {
         schedule=crontab(minute="1", hour="1", day_of_week="1"),
     ),
     "pull_users_from_firebase": CronJob(
-        task="apps.contributor.tasks.pull_users_from_firebase",
+        task="apps.contributor.tasks.pull_users_from_firebase_task",
         schedule=crontab(minute="*/1"),  # Every 1 minutes
         sentry_config=CronJobSentryConfig(
             failure_issue_threshold=10,

--- a/main/cronjobs.py
+++ b/main/cronjobs.py
@@ -59,6 +59,15 @@ SCHEDULES: dict[str, CronJob] = {
             max_runtime=2,
         ),
     ),
+    "pull_user_group_memberships_from_firebase_task": CronJob(
+        task="apps.contributor.tasks.pull_user_group_memberships_from_firebase_task",
+        schedule=crontab(minute="*/2"),  # Every 2 minutes
+        sentry_config=CronJobSentryConfig(
+            failure_issue_threshold=10,
+            checkin_margin=2,
+            max_runtime=2,
+        ),
+    ),
     "pull_mapping_session_from_firebase": CronJob(
         task="apps.mapping.tasks.pull_mapping_session_from_firebase",
         schedule=crontab(minute="*/2"),  # Every 2 minutes


### PR DESCRIPTION
## Changes

* fix task name for firebase user pull
* add cron to get user group membership data

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [x] translations
