### PR TITLE
Fix sync issue with usergroup membership and project exports

### DIFF
--- a/apps/contributor/firebase/pull.py
+++ b/apps/contributor/firebase/pull.py
@@ -78,7 +78,7 @@ def pull_user_group_memberships_from_firebase():
             firebase_id=key,
             contributor_user_group_firebase_id=valid_membership_log.userGroupId,
             contributor_user_firebase_id=valid_membership_log.userId,
-            date=datetime.datetime.fromtimestamp(valid_membership_log.timestamp),
+            date=datetime.datetime.fromtimestamp(int(valid_membership_log.timestamp / 1000)),
             action=ContributorUserGroupMembershipLogActionEnum.from_firebase(valid_membership_log.action),
         )
         bulk_create_manager.add(membership_log)

--- a/apps/contributor/firebase/push.py
+++ b/apps/contributor/firebase/push.py
@@ -87,7 +87,7 @@ class FirebaseContributorUserGroup(FirebasePush[ContributorUserGroup, firebase_e
     @typing.override
     def handle_new_object_on_firebase(self, model_obj: ContributorUserGroup, fb_reference: FbReference):
         contributor_user_group_data = firebase_ext_models.FbUserGroup(
-            createdAt=int(model_obj.created_at.timestamp()),
+            createdAt=int(model_obj.created_at.timestamp() * 1000),
             # FIXME: What to use for fallback?
             createdBy=model_obj.created_by.firebase_id or str(model_obj.created_by_id),
             description=model_obj.description,

--- a/apps/contributor/tests/firebase_test.py
+++ b/apps/contributor/tests/firebase_test.py
@@ -258,7 +258,8 @@ class TestContributorFirebase(TestCase):
         # Firebase User Group:                          Ramayan
         # Firebase User Group Membership:               ...
         # Firebase User Group Membership Updates:       ...
-        now = int(datetime.datetime.now().timestamp())
+        now = int(datetime.datetime(year=2012, month=6, day=15).timestamp())
+        day = 86400
 
         # Create users in both firebase and database
         ram = ContributorUserFactory.create(username="ram")
@@ -321,7 +322,7 @@ class TestContributorFirebase(TestCase):
             laxman,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.JOIN,
-            now + 1,
+            now + day,
         )
         pull_user_group_memberships_from_firebase()
 
@@ -339,32 +340,32 @@ class TestContributorFirebase(TestCase):
             ram,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.LEAVE,
-            now + 2,
+            now + 2 * day,
         )
         self._send_membership_request_to_firebase(
             ram,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.JOIN,
-            now + 3,
+            now + 3 * day,
         )
         # Pull 3: Laxman leaves, joins and leaves again
         self._send_membership_request_to_firebase(
             laxman,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.LEAVE,
-            now + 2,
+            now + 2 * day,
         )
         self._send_membership_request_to_firebase(
             laxman,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.JOIN,
-            now + 3,
+            now + 3 * day,
         )
         self._send_membership_request_to_firebase(
             laxman,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.LEAVE,
-            now + 4,
+            now + 4 * day,
         )
         # Pull 3: Sita joins and leaves (but this action occurred on Pull 0)
         # NOTE: This should not deactivate Sita
@@ -372,13 +373,13 @@ class TestContributorFirebase(TestCase):
             sita,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.JOIN,
-            now - 2,
+            now - 2 * day,
         )
         self._send_membership_request_to_firebase(
             sita,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.LEAVE,
-            now - 1,
+            now - 1 * day,
         )
         pull_user_group_memberships_from_firebase()
 
@@ -407,19 +408,19 @@ class TestContributorFirebase(TestCase):
             yudhistir,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.JOIN,
-            now + 5,
+            now + 5 * day,
         )
         bheem_membership_key = self._send_membership_request_to_firebase(
             bheem,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.JOIN,
-            now + 5,
+            now + 5 * day,
         )
         self._send_membership_request_to_firebase(
             ravan,
             ramayan,
             ContributorUserGroupMembershipLogActionEnum.JOIN,
-            now + 5,
+            now + 5 * day,
         )
         pull_user_group_memberships_from_firebase()
 

--- a/apps/mapping/firebase/utils.py
+++ b/apps/mapping/firebase/utils.py
@@ -96,8 +96,10 @@ class FirebaseCleanup:
     def done(self):
         if self._mapping_sessions:
             logger.info("Cleanup up firebase results")
+
+            project_firebase_ids = set([mapping_session.split("/")[0] for mapping_session in self._mapping_sessions])
             # Trigger generate_project_exports for updated projects
-            for project_firebase_id in self._mapping_sessions:
+            for project_firebase_id in project_firebase_ids:
                 transaction.on_commit(
                     # XXX: we loose type check with s (signature)
                     generate_project_exports.s(project_firebase_id=project_firebase_id).delay,


### PR DESCRIPTION
## Changes

* Transform timestamps for usergroup and usergroup membership
* Use first part of the key to get projects for export

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
