### PR TITLE
feat(admin): make django form selection lazy

### DIFF
--- a/apps/common/admin.py
+++ b/apps/common/admin.py
@@ -10,20 +10,20 @@ from apps.common.models import UserResource
 DjangoModel = typing.TypeVar("DjangoModel", bound=models.Model)
 
 
-# FIXME(tnagorra): Do we use Mixin or extend admin.ModelAdmin
-# TODO(tnagorra): Use readonly mixin
-class ReadOnlyMixin:
-    def has_add_permission(self, *args, **kwargs):
-        return False
-
-    def has_change_permission(self, *args, **kwargs):
-        return False
-
-    def has_delete_permission(self, *args, **kwargs):
-        return False
-
-
 class UserResourceAdmin(admin.ModelAdmin):
+    @typing.override
+    def get_autocomplete_fields(self, *args, **kwargs):
+        autocomplete_fields = super().get_autocomplete_fields(*args, **kwargs)
+        return [
+            *dict.fromkeys(
+                [
+                    *autocomplete_fields,
+                    "created_by",
+                    "modified_by",
+                ],
+            ),
+        ]
+
     @typing.override
     def get_readonly_fields(self, *args, **kwargs):
         readonly_fields = super().get_readonly_fields(*args, **kwargs)
@@ -33,9 +33,9 @@ class UserResourceAdmin(admin.ModelAdmin):
                 [
                     *readonly_fields,
                     "created_at",
-                    "created_by",
                     "modified_at",
-                    "modified_by",
+                    # "created_by",
+                    # "modified_by",
                 ],
             ),
         ]
@@ -68,7 +68,43 @@ class UserResourceAdmin(admin.ModelAdmin):
         return super().get_queryset(request).select_related("created_by", "modified_by")
 
 
-class ArchivableResourceAdmin(UserResourceAdmin, admin.ModelAdmin):
+class ArchivableResourceAdmin(admin.ModelAdmin):
+    @typing.override
+    def get_list_display(self, *args, **kwargs):
+        list_display = super().get_list_display(*args, **kwargs)
+        return [
+            *dict.fromkeys(
+                [
+                    *list_display,
+                    "is_archived",
+                ],
+            ),
+        ]
+
+    @typing.override
+    def get_list_filter(self, *args, **kwargs):
+        list_filter = super().get_list_filter(*args, **kwargs)
+        return [
+            *dict.fromkeys(
+                [
+                    *list_filter,
+                    "is_archived",
+                ],
+            ),
+        ]
+
+    @typing.override
+    def get_autocomplete_fields(self, *args, **kwargs):
+        autocomplete_fields = super().get_autocomplete_fields(*args, **kwargs)
+        return [
+            *dict.fromkeys(
+                [
+                    *autocomplete_fields,
+                    "archived_by",
+                ],
+            ),
+        ]
+
     @typing.override
     def get_readonly_fields(self, *args, **kwargs):
         readonly_fields = super().get_readonly_fields(*args, **kwargs)
@@ -96,7 +132,35 @@ class ArchivableResourceAdmin(UserResourceAdmin, admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
 
-class FirebaseResourceAdmin(UserResourceAdmin, admin.ModelAdmin):
+class FirebaseResourceAdmin(admin.ModelAdmin):
+    # FIXME(tnagorra): Add ordering for firebase_last_pushed
+
+    @typing.override
+    def get_list_display(self, *args, **kwargs):
+        list_display = super().get_list_display(*args, **kwargs)
+        return [
+            *dict.fromkeys(
+                [
+                    "firebase_id",
+                    *list_display,
+                    "firebase_last_pushed",
+                    "firebase_push_status",
+                ],
+            ),
+        ]
+
+    @typing.override
+    def get_list_filter(self, *args, **kwargs):
+        list_filter = super().get_list_filter(*args, **kwargs)
+        return [
+            *dict.fromkeys(
+                [
+                    *list_filter,
+                    "firebase_push_status",
+                ],
+            ),
+        ]
+
     @typing.override
     def get_readonly_fields(self, *args, **kwargs):
         readonly_fields = super().get_readonly_fields(*args, **kwargs)
@@ -110,22 +174,3 @@ class FirebaseResourceAdmin(UserResourceAdmin, admin.ModelAdmin):
                 ],
             ),
         ]
-
-
-class ReadOnlyAdmin(admin.ModelAdmin):
-    @typing.override
-    def get_readonly_fields(self, request, obj=None):
-        # Get all model field names
-        return [f.name for f in self.model._meta.fields]
-
-    @typing.override
-    def has_add_permission(self, *args, **kwargs):
-        return False
-
-    @typing.override
-    def has_delete_permission(self, *args, **kwargs):
-        return False
-
-    @typing.override
-    def has_change_permission(self, request, obj=None):
-        return False

--- a/apps/contributor/admin.py
+++ b/apps/contributor/admin.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 from djangoql.admin import DjangoQLSearchMixin
 
-from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin, ReadOnlyAdmin
+from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin, UserResourceAdmin
 
 from .firebase.push import FirebaseContributorTeam, FirebaseContributorUser
 from .models import ContributorTeam, ContributorUser, ContributorUserGroup, ContributorUserGroupMembership
@@ -13,12 +13,6 @@ from .models import ContributorTeam, ContributorUser, ContributorUserGroup, Cont
 
 @admin.register(ContributorUser)
 class ContributorUserAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
-    list_display = (
-        "firebase_id",
-        "username",
-        "created_at",
-        "modified_at",
-    )
     readonly_fields = (
         "firebase_id",
         "old_id",
@@ -28,7 +22,12 @@ class ContributorUserAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
         "created_at",
         "modified_at",
     )
-    list_filter = ("team",)
+    list_display = ("firebase_id", "username", "team", "created_at")
+    ordering = ("username", "team", "created_at")
+    search_fields = ("username",)
+    # list_filter = ("team",)
+    list_select_related = True
+    autocomplete_fields = ("team",)
 
     @typing.override
     def has_add_permission(self, *args, **kwargs):
@@ -45,25 +44,31 @@ class ContributorUserAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
 
 
 @admin.register(ContributorUserGroup)
-class ContributorUserGroupAdmin(DjangoQLSearchMixin, ArchivableResourceAdmin, FirebaseResourceAdmin, ReadOnlyAdmin):
-    pass
+class ContributorUserGroupAdmin(
+    DjangoQLSearchMixin,
+    ArchivableResourceAdmin,
+    FirebaseResourceAdmin,
+    UserResourceAdmin,
+    admin.ModelAdmin,
+):
+    list_display = ("name",)
+    ordering = ("name",)
+    search_fields = ("name",)
+    list_select_related = True
 
 
 @admin.register(ContributorTeam)
 class ContributorTeamAdmin(
-    ArchivableResourceAdmin,
     DjangoQLSearchMixin,
+    ArchivableResourceAdmin,
     FirebaseResourceAdmin,
+    UserResourceAdmin,
     admin.ModelAdmin,
 ):
-    list_display = (
-        "name",
-        "is_archived",
-        "created_at",
-        "modified_at",
-        "view_team_members",
-    )
-    list_filter = ("is_archived",)
+    list_display = ("name", "view_team_members")
+    ordering = ("name",)
+    search_fields = ("name",)
+    list_select_related = True
 
     @typing.override
     def save_model(self, request, obj, form, change):
@@ -76,9 +81,12 @@ class ContributorTeamAdmin(
 
 
 @admin.register(ContributorUserGroupMembership)
-class ContributorUserGroupMembershipAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
-    list_display = (
-        "user",
-        "user_group",
+class ContributorUserGroupMembershipAdmin(DjangoQLSearchMixin, admin.ModelAdmin):
+    list_display = ("user", "user_group", "is_active")
+    list_filter = (
+        # "user",
+        # "user_group",
         "is_active",
     )
+    list_select_related = True
+    autocomplete_fields = ("user", "user_group")

--- a/apps/project/admin.py
+++ b/apps/project/admin.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 from djangoql.admin import DjangoQLSearchMixin
 
-from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin, ReadOnlyAdmin
+from apps.common.admin import ArchivableResourceAdmin, FirebaseResourceAdmin, UserResourceAdmin
 
 from .models import Organization, Project, ProjectAsset
 
@@ -40,21 +40,52 @@ class OrganizationAdmin(
     DjangoQLSearchMixin,
     ArchivableResourceAdmin,
     FirebaseResourceAdmin,
-    ReadOnlyAdmin,
+    UserResourceAdmin,
     admin.ModelAdmin,
 ):
-    list_display = ("name",)
-    list_filter = ("name",)
+    list_display = ("name", "abbreviation")
+    search_fields = ("name", "abbreviation")
+    ordering = ("name", "abbreviation")
+    list_select_related = True
 
 
 @admin.register(Project)
-class ProjectAdmin(DjangoQLSearchMixin, FirebaseResourceAdmin, ReadOnlyAdmin, admin.ModelAdmin):
-    list_display = ("topic", "requesting_organization", "project_type", "is_private", "region")
-    list_filter = (IncludedInTeamFilter, "topic", "project_type", "is_private", "region")
+class ProjectAdmin(DjangoQLSearchMixin, FirebaseResourceAdmin, UserResourceAdmin, admin.ModelAdmin):
+    list_display = (
+        "generate_name",
+        "requesting_organization",
+        "project_type",
+        "tutorial",
+        "team",
+        "is_private",
+        "status",
+        "processing_status",
+    )
+    readonly_fields = ("generate_name",)
+    search_fields = ("topic", "region")
+    ordering = ("topic", "region")
+    list_filter = (
+        IncludedInTeamFilter,
+        # "requesting_organization",
+        # "team",
+        "project_type",
+        "is_private",
+        "status",
+        "processing_status",
+    )
     list_select_related = True
-    autocomplete_fields = ("requesting_organization", "tutorial", "image", "created_by", "team")
+    autocomplete_fields = ("requesting_organization", "team", "tutorial", "image")
 
 
 @admin.register(ProjectAsset)
-class ProjectAssetAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
-    pass
+class ProjectAssetAdmin(DjangoQLSearchMixin, UserResourceAdmin, admin.ModelAdmin):
+    list_display = ("project", "mimetype", "type", "input_type", "export_type", "file_size", "marked_as_deleted")
+    list_filter = (
+        # "project",
+        "mimetype",
+        "type",
+        "input_type",
+        "export_type",
+    )
+    list_select_related = True
+    autocomplete_fields = ("project",)

--- a/apps/tutorial/admin.py
+++ b/apps/tutorial/admin.py
@@ -1,19 +1,32 @@
 from django.contrib import admin
 from djangoql.admin import DjangoQLSearchMixin
 
-from apps.common.admin import ReadOnlyAdmin
+from apps.common.admin import UserResourceAdmin
 
 from .models import Tutorial, TutorialAsset
 
 
 @admin.register(Tutorial)
-class TutorialAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
+class TutorialAdmin(DjangoQLSearchMixin, UserResourceAdmin, admin.ModelAdmin):
     list_display = ("name", "project", "status")
-    list_filter = ("status",)
+    search_fields = ("name",)
+    ordering = ("name",)
+    list_filter = (
+        # "project",
+        "status",
+    )
     list_select_related = True
-    autocomplete_fields = ("project", "created_by")
+    autocomplete_fields = ("project",)
 
 
 @admin.register(TutorialAsset)
-class ProjectAssetAdmin(DjangoQLSearchMixin, ReadOnlyAdmin, admin.ModelAdmin):
-    pass
+class TutorialAssetAdmin(DjangoQLSearchMixin, UserResourceAdmin, admin.ModelAdmin):
+    list_display = ("tutorial", "mimetype", "type", "input_type", "file_size", "marked_as_deleted")
+    list_filter = (
+        # "tutorial",
+        "mimetype",
+        "type",
+        "input_type",
+    )
+    list_select_related = True
+    autocomplete_fields = ("tutorial",)

--- a/apps/tutorial/models.py
+++ b/apps/tutorial/models.py
@@ -100,6 +100,10 @@ class Tutorial(UserResource, FirebasePushResource):  # type: ignore[reportIncomp
     scenarios: RelatedManager["TutorialScenarioPage"]
     information_pages: RelatedManager["TutorialInformationPage"]
 
+    @typing.override
+    def __str__(self) -> str:
+        return self.name
+
     @property
     def status_enum(self) -> TutorialStatusEnum:
         return TutorialStatusEnum(self.status)

--- a/apps/user/admin.py
+++ b/apps/user/admin.py
@@ -3,8 +3,6 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.utils.translation import gettext_lazy as _
 
-from apps.common.admin import ReadOnlyAdmin
-
 from .models import User
 
 
@@ -15,18 +13,20 @@ class UserCreationForm(forms.ModelForm):
 
 
 @admin.register(User)
-class UserAdmin(DjangoUserAdmin, ReadOnlyAdmin):
+class UserAdmin(DjangoUserAdmin):
     list_display = (
         "email",
-        "contributor_user__firebase_id",
-        "contributor_user__username",
         "first_name",
         "last_name",
+        "contributor_user__firebase_id",
+        "contributor_user__username",
+        "is_active",
         "is_staff",
+        "is_superuser",
     )
     list_filter = ("is_staff", "is_superuser", "is_active", "groups")
-    search_fields = ("first_name", "last_name", "email")
-    ordering = ("email",)
+    search_fields = ("email", "first_name", "last_name")
+    ordering = ("email", "first_name", "last_name")
     add_form = UserCreationForm
     readonly_fields = ("display_name",)
     autocomplete_fields = ("contributor_user",)


### PR DESCRIPTION
## Changes

- add default filter, columns on base admin classes
- add filter and columns on admin table
- remove readonly modesl
- properly extend with archivableresource, firebaseresource, userresource

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
