### PR TITLE
feat(graphql): add contributor user in user type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: uv lock --locked --offline
 
       - name: uv sync
-        run: uv sync --all-extras
+        run: uv sync --all-groups --all-extras
 
       - uses: pre-commit/action@main
 

--- a/apps/contributor/tests/contributor_team_test.py
+++ b/apps/contributor/tests/contributor_team_test.py
@@ -1,6 +1,6 @@
 import typing
 
-import pytest  # type: ignore[reportMissingImports]
+import pytest
 from django.contrib.admin.sites import AdminSite
 from django.core.exceptions import ValidationError
 

--- a/apps/user/graphql/filters.py
+++ b/apps/user/graphql/filters.py
@@ -1,12 +1,31 @@
 import strawberry
 import strawberry_django
+from django.db import models
 
 from apps.common.filters import unaccented_filter
+from apps.contributor.graphql.filters import ContributorUserFilter
 from apps.user.models import User
 
 
 @strawberry_django.filters.filter(User, lookups=True)
 class UserFilter:
     id: strawberry.auto
-
+    contributor_user: ContributorUserFilter | None = strawberry.UNSET
     display_name = unaccented_filter("display_name")
+
+    @strawberry_django.filter_field
+    def search(
+        self,
+        queryset: models.QuerySet[User],
+        value: str,
+        prefix: str,
+    ) -> tuple[models.QuerySet[User], models.Q]:
+        return queryset, models.Q(
+            **{
+                f"{prefix}display_name__icontains": value,
+            },
+        ) | models.Q(
+            **{
+                f"{prefix}contributor_user__username__icontains": value,
+            },
+        )

--- a/apps/user/graphql/types.py
+++ b/apps/user/graphql/types.py
@@ -1,7 +1,12 @@
+import typing
+
 import strawberry
 import strawberry_django
 
 from apps.user.models import User
+
+if typing.TYPE_CHECKING:
+    from apps.contributor.graphql.types import ContributorUserType
 
 
 @strawberry_django.type(User)
@@ -11,6 +16,7 @@ class UserType:
     last_name: strawberry.auto
     display_name: strawberry.auto
     anonymize_email: str
+    contributor_user: typing.Annotated["ContributorUserType", strawberry.lazy("apps.contributor.graphql.types")] | None
 
 
 @strawberry_django.type(User)

--- a/apps/user/tests/query_test.py
+++ b/apps/user/tests/query_test.py
@@ -1,6 +1,8 @@
 import typing
 
+from apps.contributor.factories import ContributorUserFactory
 from apps.user.factories import UserFactory
+from apps.user.models import User
 from main.tests import TestCase
 
 
@@ -42,15 +44,36 @@ class TestUserQuery(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.user = UserFactory.create(email="main-user@test.com")
+
         # Some other users as well
         cls.users = (
-            UserFactory.create(first_name="Test", last_name="Hero", email="sample@test.com"),
-            UserFactory.create(first_name="Example", last_name="Villain", email="sample@vil.com"),
-            UserFactory.create(first_name="Test", last_name="Hero", email="hero-user@sample.com"),
+            UserFactory.create(
+                first_name="Test",
+                last_name="Hero",
+                email="sample@test.com",
+            ),
+            UserFactory.create(
+                first_name="Example",
+                last_name="Villain",
+                email="sample@vil.com",
+                contributor_user=ContributorUserFactory.create(username="the-real-hero"),
+            ),
+            UserFactory.create(
+                first_name="Test",
+                last_name="Hero",
+                email="hero-user@sample.com",
+                contributor_user=ContributorUserFactory.create(username="player-01"),
+            ),
         )
+
         # Inactive users (For noise)
         cls.inactive_users = [
-            UserFactory.create(first_name="Inactive", last_name="Hero", email="inactive-user@sample.com", is_active=False),
+            UserFactory.create(
+                first_name="Inactive",
+                last_name="Hero",
+                email="inactive-user@sample.com",
+                is_active=False,
+            ),
         ]
 
     def test_me(self):
@@ -111,3 +134,52 @@ class TestUserQuery(TestCase):
                 for _user in all_users
             ],
         }
+
+    def test_users_search(self):
+        QUERY = """
+            query MyQuery($search: String!) {
+              users(filters: {search: $search}) {
+                totalCount
+                results {
+                  id
+                  lastName
+                  firstName
+                  displayName
+                  contributorUser {
+                    id
+                    username
+                  }
+                }
+              }
+            }
+        """
+
+        user = self.user
+        self.force_login(user)
+
+        def _check(search: str, expected_users: list[User]):
+            content = self.query_check(QUERY, variables=dict(search=search))
+            assert content["data"]["users"] == {
+                "totalCount": len(expected_users),
+                "results": [
+                    dict(
+                        id=self.gID(user.pk),
+                        lastName=user.last_name,
+                        firstName=user.first_name,
+                        displayName=user.display_name,
+                        contributorUser=user.contributor_user
+                        and dict(
+                            id=self.gID(user.contributor_user.pk),
+                            username=user.contributor_user.username,
+                        ),
+                    )
+                    for user in expected_users
+                ],
+            }
+
+        _check("", [self.user, *self.users])
+        _check("player", [self.users[2]])
+        _check("hero", [*self.users])
+        _check("villain", [self.users[1]])
+        _check("test", [self.users[0], self.users[2]])
+        _check("none-existing-name", [])

--- a/schema.graphql
+++ b/schema.graphql
@@ -2350,8 +2350,14 @@ input UserFilter {
   DISTINCT: Boolean
   NOT: UserFilter
   OR: UserFilter
+
+  """
+  The Contributor user associated with this User. This will also be used for authentication using firebase.
+  """
+  contributorUser: ContributorUserFilter
   displayName: String
   id: IDBaseFilterLookup
+  search: String
 }
 
 """
@@ -2364,6 +2370,11 @@ can be accurately synchronized back to Firebase with the correct user associatio
 """
 type UserMeType {
   anonymizeEmail: String!
+
+  """
+  The Contributor user associated with this User. This will also be used for authentication using firebase.
+  """
+  contributorUser: ContributorUserType
   displayName: String!
   email: String!
   firstName: String!
@@ -2394,6 +2405,11 @@ can be accurately synchronized back to Firebase with the correct user associatio
 """
 type UserType {
   anonymizeEmail: String!
+
+  """
+  The Contributor user associated with this User. This will also be used for authentication using firebase.
+  """
+  contributorUser: ContributorUserType
   displayName: String!
   firstName: String!
   id: ID!

--- a/utils/tests/common_test.py
+++ b/utils/tests/common_test.py
@@ -2,7 +2,7 @@ import gzip
 import json
 import typing
 
-import pytest  # type: ignore[reportMissingImports]
+import pytest
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from pydantic_core import ValidationError as PydanticValidationError


### PR DESCRIPTION
Addresses
- Contributor user attributes in Manager User

## Changes

- add field contributor user in UserType and UserMeType
- add search and Contributor user fields in user filters

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
