### PR TITLE
Return field level validation on serializers where possible

### DIFF
--- a/apps/common/serializers.py
+++ b/apps/common/serializers.py
@@ -180,10 +180,20 @@ class CommonAssetSerializer(serializers.ModelSerializer[CommonAsset]):
         external_url: ContentFile[bytes] | None = attrs.get("external_url")
 
         if not file_content and not external_url:
-            raise serializers.ValidationError(gettext("Either file or external_url must be defined"))
+            raise serializers.ValidationError(
+                {
+                    "file": gettext("Either file or external_url must be defined"),
+                    "external_url": gettext("Either file or external_url must be defined"),
+                },
+            )
 
         if file_content and external_url:
-            raise serializers.ValidationError(gettext("Both file and external_url cannot be defined"))
+            raise serializers.ValidationError(
+                {
+                    "file": gettext("Both file and external_url cannot be defined"),
+                    "external_url": gettext("Both file and external_url cannot be defined"),
+                },
+            )
 
     def _validate_file_size(self, attrs: dict[str, typing.Any]) -> None:
         file_content: ContentFile[bytes] | None = attrs.get("file")
@@ -193,11 +203,13 @@ class CommonAssetSerializer(serializers.ModelSerializer[CommonAsset]):
 
         if file_content.size > CommonAsset.MAX_FILE_SIZE:
             raise serializers.ValidationError(
-                gettext("Filesize should be less than: %s. Current is: %s")
-                % (
-                    filesizeformat(CommonAsset.MAX_FILE_SIZE),
-                    filesizeformat(file_content.size),
-                ),
+                {
+                    "file": gettext("Filesize should be less than: %s. Current is: %s")
+                    % (
+                        filesizeformat(CommonAsset.MAX_FILE_SIZE),
+                        filesizeformat(file_content.size),
+                    ),
+                },
             )
         attrs["file_size"] = file_content.size
 
@@ -213,7 +225,9 @@ class CommonAssetSerializer(serializers.ModelSerializer[CommonAsset]):
         mimetype = magic.from_buffer(file_head, mime=True)
         if not CommonAsset.Mimetype.is_valid_mimetype(mimetype):
             raise serializers.ValidationError(
-                gettext("File mimetype is not supported: %s") % mimetype,
+                {
+                    "file": gettext("File mimetype is not supported: %s") % mimetype,
+                },
             )
 
         detected_mimetype = CommonAsset.Mimetype.get_mimetype_by_label(mimetype)

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -144,6 +144,7 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
 
     def _validate_project_instruction(self, attrs: dict[str, typing.Any]):
         assert self.instance is not None
+        # NOTE: project_instruction is not required in the database
         project_instruction = attrs.get("project_instruction") or self.instance.project_instruction
         if not project_instruction:
             raise serializers.ValidationError(
@@ -210,7 +211,11 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
         assert self.instance is not None
 
         if self.instance.status_enum not in [Project.Status.DRAFT, Project.Status.FAILED]:
-            raise serializers.ValidationError(gettext("Cannot update project with status %s") % self.instance.status)
+            raise serializers.ValidationError(
+                {
+                    "status": gettext("Cannot update project with status %s") % self.instance.status,
+                },
+            )
 
         self._validate_project_instruction(attrs)
         self._validate_project_type_specifics(attrs)
@@ -285,6 +290,7 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
 
     def _validate_project_instruction(self, attrs: dict[str, typing.Any]):
         assert self.instance is not None
+        # NOTE: project_instruction is not required in the database
         project_instruction = attrs.get("project_instruction") or self.instance.project_instruction
         if not project_instruction:
             raise serializers.ValidationError(
@@ -298,7 +304,11 @@ class ProcessedProjectSerializer(UserResourceSerializer[Project]):
         assert self.instance is not None
 
         if self.instance.status_enum != Project.Status.READY:
-            raise serializers.ValidationError(gettext("Cannot update project with status %s") % self.instance.status)
+            raise serializers.ValidationError(
+                {
+                    "status": gettext("Cannot update project with status %s") % self.instance.status,
+                },
+            )
 
         self._validate_project_instruction(attrs)
 
@@ -325,22 +335,38 @@ class ProjectAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Proje
     ) -> None:
         file: ContentFile[bytes] | None = attrs.get("file")
         if not file:
-            raise ValidationError("Required field file is not provided.")
+            raise ValidationError(
+                {
+                    "file": "Required field file is not provided.",
+                },
+            )
 
         if not mimetype or mimetype not in [AssetMimetypeEnum.JSON, AssetMimetypeEnum.GEOJSON, AssetMimetypeEnum.PLAINTEXT]:
-            raise ValidationError("Mimetype is should either be a Text, JSON or GeoJSON")
+            raise ValidationError(
+                {
+                    "file": "Mimetype is should either be a Text, JSON or GeoJSON",
+                },
+            )
 
         try:
             geojson_data = json.load(file)
         except json.JSONDecodeError as e:
-            raise ValidationError("Invalid JSON format in the file.") from e
+            raise ValidationError(
+                {
+                    "file": "Invalid JSON format in the file.",
+                },
+            ) from e
 
         AoiGeometryFeature = Feature[Polygon | MultiPolygon, dict]
         AoiGeometryFeatureCollection = FeatureCollection[AoiGeometryFeature]
 
         feature_collection = AoiGeometryFeatureCollection.model_validate(geojson_data)
         if len(feature_collection.features) > 20:
-            raise ValidationError("AOI Geometry must have at max 20 features")
+            raise ValidationError(
+                {
+                    "file": "AOI Geometry must have at max 20 features",
+                },
+            )
 
         geometries: list[GEOSGeometry] = []
         for feature in feature_collection.features:
@@ -357,8 +383,13 @@ class ProjectAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Proje
 
         # FIXME(tnagorra): We need to change AOI geometry to 20 sq.km.
         # Increasing this to 40 because of failing tests
-        if area * 10000 > 40:
-            raise ValidationError("Area for AOI Geometry must have less than 40 sq. km")
+        MAX_AOI_GEOMETRY_AREA = 40
+        if area * 10000 > MAX_AOI_GEOMETRY_AREA:
+            raise ValidationError(
+                {
+                    "file": f"Area for AOI Geometry must have less than {MAX_AOI_GEOMETRY_AREA} sq. km",
+                },
+            )
 
         asset_specifics = {
             "aoi_geometry": {
@@ -378,14 +409,22 @@ class ProjectAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Proje
     ) -> None:
         file: ContentFile[bytes] | None = attrs.get("file")
         if not file:
-            raise ValidationError("Required field file is not provided.")
+            raise ValidationError(
+                {
+                    "file": "Required field file is not provided.",
+                },
+            )
 
         if not mimetype or mimetype not in [
             AssetMimetypeEnum.IMAGE_GIF,
             AssetMimetypeEnum.IMAGE_JPEG,
             AssetMimetypeEnum.IMAGE_PNG,
         ]:
-            raise ValidationError("Mimetype is should either be a Jpeg, Png or Gif")
+            raise ValidationError(
+                {
+                    "file": "Mimetype is should either be a Jpeg, Png or Gif",
+                },
+            )
 
     def _validate_object_image(
         self,
@@ -401,7 +440,11 @@ class ProjectAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Proje
             AssetMimetypeEnum.IMAGE_JPEG,
             AssetMimetypeEnum.IMAGE_PNG,
         ]:
-            raise ValidationError("Mimetype is should either be a Jpeg, Png or Gif")
+            raise ValidationError(
+                {
+                    "file": "Mimetype is should either be a Jpeg, Png or Gif",
+                },
+            )
 
     def _validate_asset_type_specifics(
         self,
@@ -512,14 +555,25 @@ class ProjectStatusUpdateSerializer(UserResourceSerializer[Project]):
 
         # NOTE: This check should technically never be called.
         if not self.instance.project_instruction:
-            raise serializers.ValidationError(gettext("Project instruction is required."))
+            raise serializers.ValidationError(
+                {
+                    "project_instruction": gettext("Project instruction is required."),
+                },
+            )
 
         if new_status == Project.Status.MARKED_AS_READY and not self.instance.project_type_specifics:
             raise serializers.ValidationError(
-                gettext("project_type_specifics is required when project status is %s") % (new_status.label),
+                {
+                    "project_type_specifics": gettext("project_type_specifics is required when project status is %s")
+                    % (new_status.label),
+                },
             )
         if new_status == Project.Status.PUBLISHED and not self.instance.tutorial:
-            raise serializers.ValidationError(gettext("Tutorial is required before publishing a project."))
+            raise serializers.ValidationError(
+                {
+                    "tutorial": gettext("Tutorial is required before publishing a project."),
+                },
+            )
         return attrs
 
     @typing.override

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -803,7 +803,7 @@ class TestProjectMutation(TestCase):
             {
                 "array_errors": None,
                 "client_id": latest_project.client_id,
-                "field": "nonFieldErrors",
+                "field": "projectTypeSpecifics",
                 "messages": "project_type_specifics is required when project status is Marked as Ready",
                 "object_errors": None,
                 "pydantic_errors": None,
@@ -1505,7 +1505,7 @@ class TestProjectTypeMutation(TestCase):
             {
                 "array_errors": None,
                 "client_id": project_client_id,
-                "field": "nonFieldErrors",
+                "field": "tutorial",
                 "messages": "Tutorial is required before publishing a project.",
                 "object_errors": None,
                 "pydantic_errors": None,

--- a/apps/tutorial/serializers.py
+++ b/apps/tutorial/serializers.py
@@ -437,14 +437,22 @@ class TutorialAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Tuto
     ) -> None:
         file: ContentFile[bytes] | None = attrs.get("file")
         if not file:
-            raise ValidationError("Required field file is not provided.")
+            raise ValidationError(
+                {
+                    "file": "Required field file is not provided.",
+                },
+            )
 
         if not mimetype or mimetype not in [
             AssetMimetypeEnum.IMAGE_GIF,
             AssetMimetypeEnum.IMAGE_JPEG,
             AssetMimetypeEnum.IMAGE_PNG,
         ]:
-            raise ValidationError("Mimetype is should either be a Jpeg, Png or Gif")
+            raise ValidationError(
+                {
+                    "file": "Mimetype is should either be a Jpeg, Png or Gif",
+                },
+            )
 
     @typing.override
     def validate(self, attrs: dict[str, typing.Any]) -> dict[str, typing.Any]:

--- a/apps/tutorial/serializers.py
+++ b/apps/tutorial/serializers.py
@@ -470,10 +470,8 @@ class TutorialStatusUpdateSerializer(UserResourceSerializer[Tutorial]):
         model = Tutorial
         fields = ("status",)
 
-    @typing.override
-    def validate(self, attrs: dict[str, typing.Any]):
+    def validate_status(self, new_status: Tutorial.Status | int) -> Tutorial.Status:
         assert self.instance is not None, "Tutorial does not exist."
-        new_status = attrs.get("status")
 
         if not isinstance(new_status, Tutorial.Status):
             new_status = Tutorial.Status(new_status)
@@ -489,7 +487,7 @@ class TutorialStatusUpdateSerializer(UserResourceSerializer[Tutorial]):
                     new_status.label,
                 ),
             )
-        return super().validate(attrs)
+        return new_status
 
     @typing.override
     def update(self, instance: Tutorial, validated_data: dict[typing.Any, typing.Any]):


### PR DESCRIPTION
## Changes

* Use field level validation for tutorial status mutation
* Return field level validation where possible

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
