### PR TITLE
feat(street): Street tutorial task generation

### DIFF
--- a/apps/tutorial/graphql/inputs/inputs.py
+++ b/apps/tutorial/graphql/inputs/inputs.py
@@ -23,6 +23,7 @@ import apps.project.graphql.inputs.asset_types  # noqa: F401  # isort: skip # ty
 from .project_types.compare import CompareTutorialTaskPropertyInput
 from .project_types.completeness import CompletenessTutorialTaskPropertyInput
 from .project_types.find import FindTutorialTaskPropertyInput
+from .project_types.street import StreetTutorialTaskPropertyInput
 from .project_types.validate import ValidateTutorialTaskPropertyInput
 from .project_types.validate_image import ValidateImageTutorialTaskPropertyInput
 
@@ -34,6 +35,7 @@ class TutorialTaskProjectTypeSpecificInput:
     validate: ValidateTutorialTaskPropertyInput | None = strawberry.UNSET
     validate_image: ValidateImageTutorialTaskPropertyInput | None = strawberry.UNSET
     completeness: CompletenessTutorialTaskPropertyInput | None = strawberry.UNSET
+    street: StreetTutorialTaskPropertyInput | None = strawberry.UNSET
 
 
 @strawberry_django.input(TutorialTask)

--- a/apps/tutorial/graphql/inputs/project_types/street.py
+++ b/apps/tutorial/graphql/inputs/project_types/street.py
@@ -1,0 +1,7 @@
+import strawberry
+
+from project_types.street import tutorial as street_tutorial
+
+
+@strawberry.experimental.pydantic.input(model=street_tutorial.StreetTutorialTaskProperty, all_fields=True)
+class StreetTutorialTaskPropertyInput: ...

--- a/apps/tutorial/graphql/types/project_types/street.py
+++ b/apps/tutorial/graphql/types/project_types/street.py
@@ -1,7 +1,0 @@
-import strawberry
-
-from project_types.street import tutorial as street_tutorial
-
-
-@strawberry.experimental.pydantic.type(model=street_tutorial.StreetTutorialTaskProperty, all_fields=True)
-class StreetTutorialTaskPropertyType: ...

--- a/apps/tutorial/graphql/types/project_types/street.py
+++ b/apps/tutorial/graphql/types/project_types/street.py
@@ -1,0 +1,7 @@
+import strawberry
+
+from project_types.street import tutorial as street_tutorial
+
+
+@strawberry.experimental.pydantic.type(model=street_tutorial.StreetTutorialTaskProperty, all_fields=True)
+class StreetTutorialTaskPropertyType: ...

--- a/apps/tutorial/graphql/types/types.py
+++ b/apps/tutorial/graphql/types/types.py
@@ -17,7 +17,6 @@ from apps.tutorial.models import (
 
 import apps.project.graphql.types.asset_types  # noqa: F401  # isort: skip # type: ignore[reportUnusedImport]
 
-from project_types.street import tutorial as street_tutorial
 from project_types.tile_map_service.compare import tutorial as compare_tutorial
 from project_types.tile_map_service.completeness import tutorial as completeness_tutorial
 from project_types.tile_map_service.find import tutorial as find_tutorial
@@ -27,7 +26,6 @@ from project_types.validate_image import tutorial as validate_image_tutorial
 from .project_types.compare import CompareTutorialTaskPropertyType
 from .project_types.completeness import CompletenessTutorialTaskPropertyType
 from .project_types.find import FindTutorialTaskPropertyType
-from .project_types.street import StreetTutorialTaskPropertyType
 from .project_types.validate import ValidateTutorialTaskPropertyType
 from .project_types.validate_image import ValidateImageTutorialTaskPropertyType
 
@@ -64,7 +62,6 @@ class TutorialTaskType(UserResourceTypeMixin):
         | ValidateTutorialTaskPropertyType
         | ValidateImageTutorialTaskPropertyType
         | CompletenessTutorialTaskPropertyType
-        | StreetTutorialTaskPropertyType
         | None
     ):
         data = task.project_type_specifics
@@ -95,10 +92,7 @@ class TutorialTaskType(UserResourceTypeMixin):
                 completeness_tutorial.CompletenessTutorialTaskProperty.model_validate(data),
             )
         if project_type_enum == Project.Type.STREET:
-            return typing.cast(
-                "StreetTutorialTaskPropertyType",
-                street_tutorial.StreetTutorialTaskProperty.model_validate(data),
-            )
+            return None
         typing.assert_never(project_type_enum)
 
 

--- a/apps/tutorial/graphql/types/types.py
+++ b/apps/tutorial/graphql/types/types.py
@@ -17,6 +17,7 @@ from apps.tutorial.models import (
 
 import apps.project.graphql.types.asset_types  # noqa: F401  # isort: skip # type: ignore[reportUnusedImport]
 
+from project_types.street import tutorial as street_tutorial
 from project_types.tile_map_service.compare import tutorial as compare_tutorial
 from project_types.tile_map_service.completeness import tutorial as completeness_tutorial
 from project_types.tile_map_service.find import tutorial as find_tutorial
@@ -26,6 +27,7 @@ from project_types.validate_image import tutorial as validate_image_tutorial
 from .project_types.compare import CompareTutorialTaskPropertyType
 from .project_types.completeness import CompletenessTutorialTaskPropertyType
 from .project_types.find import FindTutorialTaskPropertyType
+from .project_types.street import StreetTutorialTaskPropertyType
 from .project_types.validate import ValidateTutorialTaskPropertyType
 from .project_types.validate_image import ValidateImageTutorialTaskPropertyType
 
@@ -62,6 +64,7 @@ class TutorialTaskType(UserResourceTypeMixin):
         | ValidateTutorialTaskPropertyType
         | ValidateImageTutorialTaskPropertyType
         | CompletenessTutorialTaskPropertyType
+        | StreetTutorialTaskPropertyType
         | None
     ):
         data = task.project_type_specifics
@@ -92,7 +95,10 @@ class TutorialTaskType(UserResourceTypeMixin):
                 completeness_tutorial.CompletenessTutorialTaskProperty.model_validate(data),
             )
         if project_type_enum == Project.Type.STREET:
-            return None
+            return typing.cast(
+                "StreetTutorialTaskPropertyType",
+                street_tutorial.StreetTutorialTaskProperty.model_validate(data),
+            )
         typing.assert_never(project_type_enum)
 
 

--- a/project_types/street/tutorial.py
+++ b/project_types/street/tutorial.py
@@ -1,6 +1,5 @@
 import typing
 
-from osgeo import ogr
 from pyfirebase_mapswipe import extended_models as firebase_ext_models
 from pyfirebase_mapswipe import models as firebase_models
 
@@ -8,10 +7,13 @@ from apps.project.models import ProjectTypeEnum
 from apps.tutorial.models import Tutorial, TutorialTask
 from project_types.base import tutorial as base_tutorial
 from project_types.street.project import StreetProjectProperty
-from utils.geo.transform import convert_json_str_to_wkt
+from utils import fields as custom_fields
 
 
-class StreetTutorialTaskProperty(base_tutorial.BaseTutorialTaskProperty): ...
+class StreetTutorialTaskProperty(base_tutorial.BaseTutorialTaskProperty):
+    mapillary_image_id: custom_fields.PydanticLongText
+    # NOTE: geometry is not used but we are saving this for the records
+    geometry: str
 
 
 class StreetTutorial(
@@ -32,10 +34,11 @@ class StreetTutorial(
 
     @typing.override
     def get_task_specifics_for_firebase(self, task: TutorialTask, index: int):
+        task_specifics = self.tutorial_task_property_class.model_validate(task.project_type_specifics)
         return firebase_models.FbStreetTutorialTask(
             projectId=self.tutorial.firebase_id,
             groupId=self.get_tutorial_group_key(),
-            taskId=f"{index}",
+            taskId=task_specifics.mapillary_image_id,
             geometry="",
             referenceAnswer=task.reference,
             screen=task.scenario.scenario_page_number,

--- a/project_types/street/tutorial.py
+++ b/project_types/street/tutorial.py
@@ -1,5 +1,7 @@
 import typing
 
+from osgeo import ogr
+from pyfirebase_mapswipe import extended_models as firebase_ext_models
 from pyfirebase_mapswipe import models as firebase_models
 
 from apps.project.models import ProjectTypeEnum
@@ -9,12 +11,9 @@ from project_types.street.project import StreetProjectProperty
 from utils.geo.transform import convert_json_str_to_wkt
 
 
-class StreetTutorialTaskProperty(base_tutorial.BaseTutorialTaskProperty):
-    # FIXME(tnagorra): Use geometry from TutorialTask
-    object_geometry: str
+class StreetTutorialTaskProperty(base_tutorial.BaseTutorialTaskProperty): ...
 
 
-# TODO(susilnem): This is not finalized
 class StreetTutorial(
     base_tutorial.BaseTutorial[
         StreetProjectProperty,
@@ -28,19 +27,23 @@ class StreetTutorial(
         super().__init__(tutorial)
 
     @typing.override
+    def compress_tasks_on_firebase(self) -> bool:
+        return True
+
+    @typing.override
     def get_task_specifics_for_firebase(self, task: TutorialTask, index: int):
-        task_specifics = self.tutorial_task_property_class(
-            **task.project_type_specifics,
-        )
-
-        geometry_wkt = convert_json_str_to_wkt(task_specifics.object_geometry)
-
         return firebase_models.FbStreetTutorialTask(
-            taskId=f"t{index}",
-            geometry=geometry_wkt,
-            screen=task.scenario.scenario_page_number,
+            projectId=self.tutorial.firebase_id,
+            groupId=self.get_tutorial_group_key(),
+            taskId=f"{index}",
+            geometry="",
             referenceAnswer=task.reference,
+            screen=task.scenario.scenario_page_number,
         )
+
+    @typing.override
+    def get_group_specifics_for_firebase(self):
+        return firebase_ext_models.FbEmptyModel()
 
     @typing.override
     def get_tutorial_specifics_for_firebase(self):
@@ -50,7 +53,6 @@ class StreetTutorial(
         assert projectType == 7, "Project Street should be 7"
 
         return firebase_models.FbStreetTutorial(
-            zoomLevel=14,
             projectType=projectType,
             customOptions=[
                 firebase_models.FbObjCustomOption(

--- a/schema.graphql
+++ b/schema.graphql
@@ -326,7 +326,7 @@ type CompareTutorialTaskPropertyType {
   tileZ: Int!
 }
 
-union CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyTypeStreetTutorialTaskPropertyType = CompareTutorialTaskPropertyType | CompletenessTutorialTaskPropertyType | FindTutorialTaskPropertyType | StreetTutorialTaskPropertyType | ValidateImageTutorialTaskPropertyType | ValidateTutorialTaskPropertyType
+union CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyType = CompareTutorialTaskPropertyType | CompletenessTutorialTaskPropertyType | FindTutorialTaskPropertyType | ValidateImageTutorialTaskPropertyType | ValidateTutorialTaskPropertyType
 
 input CompletenessProjectPropertyInput {
   """Numeric value as string"""
@@ -2152,10 +2152,6 @@ type StreetProjectPropertyType {
   mapillaryImageFilters: StreetMapillaryImageFilters!
 }
 
-type StreetTutorialTaskPropertyType {
-  objectGeometry: String!
-}
-
 """Model representing assets for a tutorial."""
 input TutorialAssetCreateInput {
   clientId: String!
@@ -2505,7 +2501,7 @@ type TutorialTaskType implements UserResourceTypeMixin {
   id: ID!
   modifiedAt: DateTime!
   modifiedBy: UserType!
-  projectTypeSpecifics: CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyTypeStreetTutorialTaskPropertyType
+  projectTypeSpecifics: CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyType
   reference: Int!
   scenarioId: ID!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -326,7 +326,7 @@ type CompareTutorialTaskPropertyType {
   tileZ: Int!
 }
 
-union CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyType = CompareTutorialTaskPropertyType | CompletenessTutorialTaskPropertyType | FindTutorialTaskPropertyType | ValidateImageTutorialTaskPropertyType | ValidateTutorialTaskPropertyType
+union CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyTypeStreetTutorialTaskPropertyType = CompareTutorialTaskPropertyType | CompletenessTutorialTaskPropertyType | FindTutorialTaskPropertyType | StreetTutorialTaskPropertyType | ValidateImageTutorialTaskPropertyType | ValidateTutorialTaskPropertyType
 
 input CompletenessProjectPropertyInput {
   """Numeric value as string"""
@@ -2152,6 +2152,16 @@ type StreetProjectPropertyType {
   mapillaryImageFilters: StreetMapillaryImageFilters!
 }
 
+input StreetTutorialTaskPropertyInput {
+  geometry: String!
+  mapillaryImageId: String!
+}
+
+type StreetTutorialTaskPropertyType {
+  geometry: String!
+  mapillaryImageId: String!
+}
+
 """Model representing assets for a tutorial."""
 input TutorialAssetCreateInput {
   clientId: String!
@@ -2489,6 +2499,7 @@ input TutorialTaskProjectTypeSpecificInput @oneOf {
   compare: CompareTutorialTaskPropertyInput
   completeness: CompletenessTutorialTaskPropertyInput
   find: FindTutorialTaskPropertyInput
+  street: StreetTutorialTaskPropertyInput
   validate: ValidateTutorialTaskPropertyInput
   validateImage: ValidateImageTutorialTaskPropertyInput
 }
@@ -2501,7 +2512,7 @@ type TutorialTaskType implements UserResourceTypeMixin {
   id: ID!
   modifiedAt: DateTime!
   modifiedBy: UserType!
-  projectTypeSpecifics: CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyType
+  projectTypeSpecifics: CompareTutorialTaskPropertyTypeFindTutorialTaskPropertyTypeValidateTutorialTaskPropertyTypeValidateImageTutorialTaskPropertyTypeCompletenessTutorialTaskPropertyTypeStreetTutorialTaskPropertyType
   reference: Int!
   scenarioId: ID!
 }


### PR DESCRIPTION
Addresses
- Add street tutorial generation

Depends on
- https://github.com/mapswipe/mapswipe-firebase/pull/40

## Changes
- tutorial task and group creation for street type project
- Add schema for the new tutorial task and group

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
