### PR TITLE
fix(model): overwrite get_prep_value to remove empty string

### DIFF
--- a/main/fields.py
+++ b/main/fields.py
@@ -11,6 +11,12 @@ class OverwritableFileField(models.FileField):
         kwargs.setdefault("storage", storages[Config.STORAGE_OVERWRITE_KEY])
         super().__init__(*args, **kwargs)
 
+    @typing.override
+    def get_prep_value(self, value):
+        if value in ("", None):
+            return None
+        return super().get_prep_value(value)
+
 
 # XXX: monkey patching to avoid removing OverwritableFileField.__init__ type annotations
 OverwritableFileField.__init__ = OverwritableFileField.__new__init__


### PR DESCRIPTION
## Changes

* validate image dataset_file upload issue

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests

