### PR TITLE
feat(serializer): add validation for tutorial status update

### DIFF
--- a/apps/tutorial/factories.py
+++ b/apps/tutorial/factories.py
@@ -2,6 +2,8 @@ import factory
 from factory.django import DjangoModelFactory
 from ulid import ULID
 
+from apps.common.models import IconEnum
+
 from .models import (
     Tutorial,
     TutorialInformationPage,
@@ -26,6 +28,16 @@ class TutorialScenarioPageFactory(DjangoModelFactory):
 
     client_id = factory.LazyFunction(lambda: str(ULID()))
     scenario_page_number = factory.Sequence(lambda n: n)
+    instructions_icon = IconEnum.ADD_OUTLINE
+    instructions_title = factory.Sequence(lambda n: f"Instruction title for page {n}")
+
+    hint_description = factory.Sequence(lambda n: f"Hint description for page {n}")
+    hint_icon = IconEnum.ADD_OUTLINE
+    hint_title = factory.Sequence(lambda n: f"Hint title for page {n}")
+
+    success_description = factory.Sequence(lambda n: f"success description for page {n}")
+    success_icon = IconEnum.ADD_OUTLINE
+    success_title = factory.Sequence(lambda n: f"success title for page {n}")
 
 
 class TutorialTaskFactory(DjangoModelFactory):

--- a/apps/tutorial/serializers.py
+++ b/apps/tutorial/serializers.py
@@ -507,6 +507,29 @@ class TutorialStatusUpdateSerializer(UserResourceSerializer[Tutorial]):
         return new_status
 
     @typing.override
+    def validate(self, attrs: dict[str, typing.Any]):
+        assert self.instance is not None
+
+        new_status = attrs.get("status")
+
+        if (
+            new_status == Tutorial.Status.READY_TO_PUBLISH
+            and not TutorialInformationPage.objects.filter(tutorial=self.instance).exists()
+        ):
+            raise serializers.ValidationError(
+                {"information_pages": gettext("At least one information page is required before publishing.")},
+            )
+
+        if (
+            new_status == Tutorial.Status.READY_TO_PUBLISH
+            and not TutorialScenarioPage.objects.filter(tutorial=self.instance).exists()
+        ):
+            raise serializers.ValidationError(
+                {"scenarios": gettext("At least one scenario is required before publishing.")},
+            )
+        return attrs
+
+    @typing.override
     def update(self, instance: Tutorial, validated_data: dict[typing.Any, typing.Any]):
         old_status_enum = instance.status_enum
         updated_tutorial = super().update(instance, validated_data)

--- a/apps/tutorial/tests/mutation_test.py
+++ b/apps/tutorial/tests/mutation_test.py
@@ -7,7 +7,11 @@ from apps.project.factories import OrganizationFactory, ProjectFactory
 from apps.project.models import (
     ProjectTypeEnum,
 )
-from apps.tutorial.factories import TutorialFactory
+from apps.tutorial.factories import (
+    TutorialFactory,
+    TutorialInformationPageFactory,
+    TutorialScenarioPageFactory,
+)
 from apps.tutorial.models import (
     Tutorial,
     TutorialStatusEnum,
@@ -653,6 +657,17 @@ class TestTutorialMutation(TestCase):
             created_by=self.user,
             modified_by=self.user,
             status=TutorialStatusEnum.DRAFT,
+        )
+        TutorialScenarioPageFactory.create(
+            tutorial=tutorial,
+            created_by=self.user,
+            modified_by=self.user,
+        )
+
+        TutorialInformationPageFactory.create(
+            tutorial=tutorial,
+            created_by=self.user,
+            modified_by=self.user,
         )
 
         # Checking with authenticated user


### PR DESCRIPTION
## Changes

* Check if tutorial has scenario and information

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
