### PR TITLE
feat(celery): Add time limits for project process tasks

### DIFF
--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -671,7 +671,19 @@ class ProjectStatusUpdateSerializer(UserResourceSerializer[Project]):
             old_status_enum != Project.Status.READY_TO_PROCESS
             and updated_project.status_enum == Project.Status.READY_TO_PROCESS
         ):
-            transaction.on_commit(lambda: process_project_task.delay(updated_project.pk))
+            if updated_project.project_type_enum in [
+                ProjectTypeEnum.VALIDATE,
+                ProjectTypeEnum.STREET,
+            ]:
+                transaction.on_commit(
+                    lambda: process_project_task.apply_async(
+                        args=(updated_project.pk,),
+                        soft_time_limit=900,  # 15 minutes
+                        time_limit=960,  # 16 minutes
+                    ),
+                )
+            else:
+                transaction.on_commit(lambda: process_project_task.delay(updated_project.pk))
 
         elif (
             old_status_enum != Project.Status.READY_TO_PUBLISH

--- a/apps/project/tests/mutation_test.py
+++ b/apps/project/tests/mutation_test.py
@@ -1560,7 +1560,7 @@ class TestProjectTypeMutation(TestCase):
         fb_project: typing.Any = project_ref.get()
         assert fb_project is not None
 
-    @patch("apps.project.serializers.process_project_task.delay")
+    @patch("apps.project.serializers.process_project_task.apply_async")
     def test_project_street(self, mock_requests):
         self.force_login(self.user)
         project_data = {
@@ -1660,4 +1660,3 @@ class TestProjectTypeMutation(TestCase):
         assert resp_data["result"]["status"] == self.genum(Project.Status.READY_TO_PROCESS)
 
         mock_requests.assert_called_once()
-        mock_requests.assert_has_calls([call(int(project_id))])


### PR DESCRIPTION
## Addresses
- Add soft time and time limit for the process tasks on project

## Changes
- Add soft time and time limit when project type is stree and validate

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
