### PR TITLE
Add test for equivalence of generate_name and generate_n…

### DIFF
--- a/apps/project/tests/query_test.py
+++ b/apps/project/tests/query_test.py
@@ -1,7 +1,7 @@
 import typing
 
 from apps.project.factories import OrganizationFactory, ProjectFactory
-from apps.project.models import ProjectTypeEnum
+from apps.project.models import Project, ProjectTypeEnum
 from apps.user.factories import UserFactory
 from main.tests import TestCase
 from utils.common import format_object_keys, to_camel_case
@@ -337,3 +337,17 @@ class TestProjectQuery(TestCase):
                 ],
             ),
         }, content
+
+        for project in self.projects:
+            generated_name = project.generate_name()
+
+            generated_name_from_query = (
+                Project.objects.filter(pk=project.pk)
+                .annotate(gen_name=Project.generate_name_query())
+                .values_list("gen_name", flat=True)
+                .get()
+            )
+
+            assert generated_name == generated_name_from_query, (
+                f"Mismatch for project {project.pk}: '{generated_name}' does not equal '{generated_name_from_query}'"
+            )

--- a/apps/project/tests/query_test.py
+++ b/apps/project/tests/query_test.py
@@ -338,16 +338,14 @@ class TestProjectQuery(TestCase):
             ),
         }, content
 
-        for project in self.projects:
+        annotated_projects = Project.objects.filter(
+            pk__in=[p.pk for p in self.projects],
+        ).annotate(
+            gen_name=Project.generate_name_query(),
+        )
+
+        for project in annotated_projects:
             generated_name = project.generate_name()
+            generated_name_from_query = project.gen_name  # type: ignore[reportAttributeAccessIssue]
 
-            generated_name_from_query = (
-                Project.objects.filter(pk=project.pk)
-                .annotate(gen_name=Project.generate_name_query())
-                .values_list("gen_name", flat=True)
-                .get()
-            )
-
-            assert generated_name == generated_name_from_query, (
-                f"Mismatch for project {project.pk}: '{generated_name}' does not equal '{generated_name_from_query}'"
-            )
+            assert generated_name == generated_name_from_query, f"Name mismatch for project {project.pk}"


### PR DESCRIPTION
## Changes

* Add test for generate_name and generate_name_query

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
- [X] permission checks (tests here too)
- [X] translations
