### PR TITLE
fix(user): change slack_user_id to empty string before field change

### DIFF
--- a/apps/user/migrations/0003_alter_user_slack_user_id.py
+++ b/apps/user/migrations/0003_alter_user_slack_user_id.py
@@ -2,6 +2,10 @@
 
 from django.db import migrations, models
 
+def update_null_to_empty_string(apps, schema_editor):
+    User = apps.get_model('user', 'User')
+    User.objects.filter(slack_user_id__isnull=True).update(slack_user_id='')
+
 
 class Migration(migrations.Migration):
 
@@ -10,6 +14,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(update_null_to_empty_string, reverse_code=migrations.RunPython.noop),
         migrations.AlterField(
             model_name='user',
             name='slack_user_id',


### PR DESCRIPTION
Addresses
- Null db constraint error

## Changes

* Update null slack_user_id to empty string

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
