### PR TITLE
fix(tutorial): fix typo in tutorial link

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -79,7 +79,7 @@ class Config:
 
         @staticmethod
         def tutorial_url(tutorial_id: int):
-            return f"{Config.MANAGER_DASHBOARD_DOMAIN.geturl()}/tutorials/{tutorial_id}/edit"
+            return f"{Config.MANAGER_DASHBOARD_DOMAIN.geturl()}/tutorial/{tutorial_id}/edit"
 
     class FirebaseKeys:
         @staticmethod


### PR DESCRIPTION
## Changes

* Fix typo in tutorial link

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
- [X] permission checks (tests here too)
- [X] translations
