### PR TITLE
chore(admin): add read only fields

### DIFF
--- a/apps/project/admin.py
+++ b/apps/project/admin.py
@@ -68,7 +68,7 @@ class ProjectAdmin(DjangoQLSearchMixin, FirebaseResourceAdmin, UserResourceAdmin
         "processing_status",
         "progress",
     )
-    readonly_fields = ("generate_name",)
+    readonly_fields = ("generate_name", "slack_progress_notifications", "slack_thread_ts")
     search_fields = ("topic", "region")
     ordering = ("topic", "region")
     list_filter = (


### PR DESCRIPTION
Make slack_thread_ts and slack_progress_notifications read only

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
- [X] permission checks (tests here too)
- [X] translations
