### PR TITLE
feat(project): increase max area to 2500sqkm for validate

### DIFF
--- a/apps/project/custom_options.py
+++ b/apps/project/custom_options.py
@@ -34,8 +34,15 @@ class CustomOptionDefaults:
             "title": "Not Sure",
             "icon": IconEnum.REMOVE_OUTLINE,
             "value": 2,
-            "description": "if you're not sure or unsure about the image",
+            "description": "you're not sure or there is cloud cover/bad imagery",
             "icon_color": "#616161",
+        },
+        {
+            "title": "Offset",
+            "icon": IconEnum.ALERT_OUTLINE,
+            "value": 3,
+            "description": "",
+            "icon_color": "#9e9e9e",
         },
     ]
 

--- a/project_types/validate/project.py
+++ b/project_types/validate/project.py
@@ -131,7 +131,9 @@ class ValidateProject(
 
     @staticmethod
     def _validate_geojson_aoi_area(area_km2: float) -> float:
-        MAX_AOI_AREA = 500
+        # NOTE: This value was previously 20sqkm. We are increasing this to 2500 to accommodate
+        # projects like https://tasks.hotosm.org/projects/4757
+        MAX_AOI_AREA = 2500
         if area_km2 > MAX_AOI_AREA:
             raise base_project.ValidationException(f"Area for AOI Geometry must be less than {MAX_AOI_AREA} sq. km")
         return area_km2


### PR DESCRIPTION
## Changes

* Increase max area constraint for validate project AOI
* Add "offset" custom option for validate project

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [ ] permission checks (tests here too)
- [ ] translations
