### PR TITLE
Pre-commit/Exclude ruff-format for uv.lock file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,15 +53,15 @@ repos:
 
   # Run the Ruff linter.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.8
+    rev: v0.15.6
     hooks:
       # Linter
       - id: ruff
-        types_or: [python, pyi, jupyter, toml]
-        args: [--fix, --exit-non-zero-on-fix]
+        types_or: [python, pyi, jupyter, pyproject]
+        args: [--fix]
       # Formatter
       - id: ruff-format
-        types_or: [python, pyi, jupyter, toml]
+        types_or: [python, pyi, jupyter, pyproject]
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.398

--- a/apps/existing_database/management/commands/loaddata_from_existing_database.py
+++ b/apps/existing_database/management/commands/loaddata_from_existing_database.py
@@ -1210,7 +1210,7 @@ class Command(BaseCommand):
         memray = None
 
         with contextlib.suppress(ImportError):
-            import memray  # type: ignore[reportMissingImports]
+            import memray  # type: ignore[reportMissingImports]  # noqa: PLC0415
 
         memray_enable = options.get("memray_enable")
 

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -351,7 +351,7 @@ class ProjectUpdateSerializer(UserResourceSerializer[Project]):
                     ) from e
 
                 try:
-                    features, geometry_collection = convert_json_dict_to_geometry_collection(geojson_data)  # type: ignore[reportUnusedVariable]
+                    _, geometry_collection = convert_json_dict_to_geometry_collection(geojson_data)
                 except Exception as e:
                     raise serializers.ValidationError(
                         {
@@ -571,7 +571,7 @@ class ProjectAssetSerializer(CommonAssetSerializer, UserResourceSerializer[Proje
             ) from e
 
         try:
-            features, geometry_collection = convert_json_dict_to_geometry_collection(geojson_data)  # type: ignore[reportUnusedVariable]
+            _, geometry_collection = convert_json_dict_to_geometry_collection(geojson_data)
         except Exception as e:
             raise serializers.ValidationError(
                 {

--- a/main/celery.py
+++ b/main/celery.py
@@ -43,7 +43,7 @@ app.conf.beat_schedule = BEAT_SCHEDULES
 
 @signals.setup_logging.connect
 def config_loggers(**_):
-    from django.conf import settings
+    from django.conf import settings  # noqa: PLC0415
 
     dictConfig(settings.LOGGING)
 

--- a/main/checks.py
+++ b/main/checks.py
@@ -7,7 +7,7 @@ from django.core.checks import Warning as DCWarning
 
 @register(Tags.compatibility)
 def celery_beat_tasks(app_configs, **kwargs):  # type: ignore[reportMissingParameterType]
-    from main.cronjobs import SCHEDULES
+    from main.cronjobs import SCHEDULES  # noqa: PLC0415
 
     # Confirm all tasks can be imported
     errors = []

--- a/main/cronjobs.py
+++ b/main/cronjobs.py
@@ -197,7 +197,7 @@ sentry_celery_beat._get_monitor_config = SentryMonkeyPatch.custom__get_monitor_c
 def update_periodic_tasks(**_):
     logger.info("Cronjob sync: Start")
     try:
-        from django_celery_beat.models import PeriodicTask
+        from django_celery_beat.models import PeriodicTask  # noqa: PLC0415
 
         base_tasks_qs = PeriodicTask.objects.filter(
             task__startswith="apps.",  # Our tasks

--- a/main/graphql/schema.py
+++ b/main/graphql/schema.py
@@ -44,7 +44,7 @@ class Query(
     community_dashboard_queries.Query,
 ):
     enums: AppEnumCollection = strawberry.field(  # type: ignore[reportGeneralTypeIssues]
-        resolver=lambda: AppEnumCollectionData(),
+        resolver=lambda: AppEnumCollectionData,
     )
 
 

--- a/main/middlewares.py
+++ b/main/middlewares.py
@@ -9,7 +9,7 @@ from main.sentry import SentryTransactionMiddlewareHelper
 
 @sync_and_async_middleware
 def sentry_middleware(get_response: typing.Any):
-    from django.conf import settings
+    from django.conf import settings  # noqa: PLC0415
 
     # One-time configuration and initialization goes here.
     graphql_urls = set([reverse("graphql")])

--- a/main/tests/base_test.py
+++ b/main/tests/base_test.py
@@ -54,7 +54,7 @@ FILE_SYSTEM_TEST_STORAGES_CONFIGS = dict(
 class TestCase(BaseTestCase):
     @typing.override
     def setUp(self):
-        from django.core.cache import cache
+        from django.core.cache import cache  # noqa: PLC0415
 
         # Clear all test cache
         logger.info("Clearing cache")
@@ -91,7 +91,7 @@ class TestCase(BaseTestCase):
         files: dict[typing.Any, typing.Any] | None = None,
         **kwargs,  # type: ignore[reportMissingParameterType]
     ) -> dict[typing.Any, typing.Any]:
-        import json
+        import json  # noqa: PLC0415
 
         if files:
             # Request type: form data

--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,7 @@ def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "main.settings")
     try:
-        from django.core.management import execute_from_command_line
+        from django.core.management import execute_from_command_line  # noqa: PLC0415
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "

--- a/project_types/base/project.py
+++ b/project_types/base/project.py
@@ -602,7 +602,7 @@ class BaseProject[
     # EXPORT
 
     def generate_exports(self):
-        from apps.project.exports.exports import export_project_data
+        from apps.project.exports.exports import export_project_data  # noqa: PLC0415
 
         # NOTE: Currently the logic is same for each project
         export_project_data(self.project)

--- a/utils/geo/tile_functions.py
+++ b/utils/geo/tile_functions.py
@@ -45,8 +45,8 @@ def lat_long_zoom_to_pixel_coords(lat: float, lon: float, zoom: int):
     sinLat = math.sin(lat * math.pi / 180.0)
     x = ((lon + 180) / 360) * 256 * math.pow(2, zoom)
     y = (0.5 - math.log((1 + sinLat) / (1 - sinLat)) / (4 * math.pi)) * 256 * math.pow(2, zoom)
-    p.x = int(math.floor(x))
-    p.y = int(math.floor(y))
+    p.x = math.floor(x)
+    p.y = math.floor(y)
     return p
 
 
@@ -64,8 +64,8 @@ def pixel_coords_zoom_to_lat_lon(pixel_x: float, pixel_y: float, zoom: int):
 def pixel_coords_to_tile_address(pixel_x: float, pixel_y: float):
     """Compute a tile address from pixel coordinates of point within tile."""
     t = _Tile()
-    t.x = int(math.floor(pixel_x / 256))
-    t.y = int(math.floor(pixel_y / 256))
+    t.x = math.floor(pixel_x / 256)
+    t.y = math.floor(pixel_y / 256)
     return t
 
 

--- a/utils/geo/tile_grouping.py
+++ b/utils/geo/tile_grouping.py
@@ -98,7 +98,7 @@ def _get_horizontal_slice(
         TileY = TileY_top
 
         # get rows
-        rows = int(math.ceil(TileHeight / 3))
+        rows = math.ceil(TileHeight / 3)
 
         ############################################################
 
@@ -215,7 +215,7 @@ def _get_vertical_slice(  # noqa: D417
         TileX = TileX_left
 
         # get columns
-        cols = int(math.ceil(TileWidth / width_threshold))
+        cols = math.ceil(TileWidth / width_threshold)
         # avoid zero division error and check if cols is smaller than zero
         if cols < 1:
             continue

--- a/utils/graphql/types.py
+++ b/utils/graphql/types.py
@@ -64,7 +64,7 @@ class MapswipeDjangoFileType:
         info: Info,
         file: strawberry.Parent[files.FieldFile],
     ) -> str:
-        from apps.common.utils import get_absolute_uri
+        from apps.common.utils import get_absolute_uri  # noqa: PLC0415
 
         return get_absolute_uri(file)
 


### PR DESCRIPTION
## Changes
- Exclude ruff format for uv.lock file 

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
