### PR TITLE
Validate/add custom User-Agent for OSM/OSMCha requests

### DIFF
--- a/main/config.py
+++ b/main/config.py
@@ -58,6 +58,14 @@ class Config:
     EXISTING_SYSTEM_API = typing.cast("URLParseResult", getattr(settings, "EXISTING_SYSTEM_API", None))
     EXISTING_SYSTEM_API_INSECURE = typing.cast("bool", getattr(settings, "EXISTING_SYSTEM_API_INSECURE", False))
 
+    # App info
+    APP_RELEASE = typing.cast("str", settings.APP_RELEASE)
+    APP_ENVIRONMENT = typing.cast("str", settings.APP_ENVIRONMENT)
+
+    DEFAULT_HEADERS = {
+        "User-Agent": f"mapswipe-{APP_ENVIRONMENT}/{APP_RELEASE}",
+    }
+
     class InternalDir:
         INTERNAL_ROOT = Path(settings.INTERNAL_ROOT)
 

--- a/project_types/validate/api_calls.py
+++ b/project_types/validate/api_calls.py
@@ -35,7 +35,7 @@ def retry_get(url: str, retries: int | None = 3, timeout: int | None = 10, to_os
         if to_osmcha:
             headers = {"Authorization": f"Token {Config.OSMCHA_API_KEY}"}
             return session.get(url, timeout=timeout, headers=headers)
-        return session.get(url, timeout=timeout)
+        return session.get(url, timeout=timeout, headers=Config.DEFAULT_HEADERS)
 
 
 # FIXME(rup): Not used anywhere


### PR DESCRIPTION
## Addresses
- 403 forbidden issue on validate osm/osmcha api calls.

## Changes
- user custom user agent `mapswipe-APP_ENVIRONMENT/APP_RELEASE`

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
