### PR TITLE
Feat: set default pagination for public queries

### DIFF
--- a/apps/project/graphql/queries.py
+++ b/apps/project/graphql/queries.py
@@ -19,6 +19,7 @@ from project_types.validate.project import ValidateProject
 from utils import fields
 from utils.geo.raster_tile_server.config import RasterConfig, RasterTileServerNameEnum, RasterTileServerNameEnumWithoutCustom
 from utils.geo.vector_tile_server.config import VectorConfig, VectorTileServerNameEnum, VectorTileServerNameEnumWithoutCustom
+from utils.graphql.pagination import PublicOffsetPaginated
 
 from .filters import OrganizationFilter, ProjectAssetFilter, ProjectFilter
 from .orders import OrganizationOrder, ProjectAssetOrder, ProjectOrder
@@ -196,7 +197,7 @@ class Query:
         return Organization.objects.exclude(is_archived=True).all()
 
     @strawberry_django.offset_paginated(
-        OffsetPaginated[OrganizationType],
+        PublicOffsetPaginated[OrganizationType],
         order=OrganizationOrder,
         filters=OrganizationFilter,
     )
@@ -228,7 +229,7 @@ class Query:
         ).all()
 
     @strawberry_django.offset_paginated(
-        OffsetPaginated[ProjectType],
+        PublicOffsetPaginated[ProjectType],
         order=ProjectOrder,
         filters=ProjectFilter,
     )

--- a/apps/project/tests/query_test.py
+++ b/apps/project/tests/query_test.py
@@ -1,7 +1,9 @@
 import typing
 
+from django.conf import settings
+
 from apps.project.factories import OrganizationFactory, ProjectFactory
-from apps.project.models import Project, ProjectTypeEnum
+from apps.project.models import Project, ProjectStatusEnum, ProjectTypeEnum
 from apps.user.factories import UserFactory
 from main.tests import TestCase
 from utils.common import format_object_keys, to_camel_case
@@ -349,3 +351,126 @@ class TestProjectQuery(TestCase):
             generated_name_from_query = project.gen_name  # type: ignore[reportAttributeAccessIssue]
 
             assert generated_name == generated_name_from_query, f"Name mismatch for project {project.pk}"
+
+
+class TestPublicQueriesQuery(TestCase):
+    class Query:
+        PUBLIC_PROJECTS = """
+            query PublicProjects($pagination: OffsetPaginationInput) {
+              publicProjects(order: {id: ASC}, pagination: $pagination) {
+                totalCount
+                pageInfo {
+                  offset
+                  limit
+                }
+                results {
+                  id
+                }
+              }
+            }
+        """
+        PUBLIC_ORGANIZATIONS = """
+            query PublicOrganizations($pagination: OffsetPaginationInput) {
+              publicOrganizations(order: {id: ASC}, pagination: $pagination) {
+                totalCount
+                pageInfo {
+                  offset
+                  limit
+                }
+                results {
+                  id
+                }
+              }
+            }
+        """
+
+    MAX_LIMIT: int = settings.STRAWBERRY_DJANGO["PUBLIC_PAGINATION_MAX_LIMIT"]
+
+    @typing.override
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.user = UserFactory.create()
+        cls.user_resource_kwargs = dict(
+            created_by=cls.user,
+            modified_by=cls.user,
+        )
+        cls.active_organization = OrganizationFactory.create(**cls.user_resource_kwargs)
+        cls.archived_organization = OrganizationFactory.create(
+            **cls.user_resource_kwargs,
+            is_archived=True,
+        )
+        cls.published_project = ProjectFactory.create(
+            **cls.user_resource_kwargs,
+            requesting_organization=cls.active_organization,
+            project_type=ProjectTypeEnum.FIND,
+            status=ProjectStatusEnum.PUBLISHED,
+        )
+        cls.paused_project = ProjectFactory.create(
+            **cls.user_resource_kwargs,
+            requesting_organization=cls.active_organization,
+            project_type=ProjectTypeEnum.FIND,
+            status=ProjectStatusEnum.PAUSED,
+        )
+        cls.finished_project = ProjectFactory.create(
+            **cls.user_resource_kwargs,
+            requesting_organization=cls.active_organization,
+            project_type=ProjectTypeEnum.FIND,
+            status=ProjectStatusEnum.FINISHED,
+        )
+        cls.draft_project = ProjectFactory.create(
+            **cls.user_resource_kwargs,
+            requesting_organization=cls.active_organization,
+            project_type=ProjectTypeEnum.FIND,
+            status=ProjectStatusEnum.DRAFT,
+        )
+
+    def test_public_projects_returns_only_public_statuses(self) -> None:
+        content = self.query_check(self.Query.PUBLIC_PROJECTS, variables={"pagination": {"limit": 10, "offset": 0}})
+        result = content["data"]["publicProjects"]
+        returned_ids = {r["id"] for r in result["results"]}
+        assert result["totalCount"] == 3
+        assert self.gID(self.published_project.pk) in returned_ids
+        assert self.gID(self.paused_project.pk) in returned_ids
+        assert self.gID(self.finished_project.pk) in returned_ids
+        assert self.gID(self.draft_project.pk) not in returned_ids
+
+    def test_public_projects_high_limit_is_capped(self) -> None:
+        for _ in range(self.MAX_LIMIT):
+            ProjectFactory.create(
+                **self.user_resource_kwargs,
+                requesting_organization=self.active_organization,
+                project_type=ProjectTypeEnum.FIND,
+                status=ProjectStatusEnum.PUBLISHED,
+            )
+        content = self.query_check(
+            self.Query.PUBLIC_PROJECTS,
+            variables={"pagination": {"limit": self.MAX_LIMIT + 10, "offset": 0}},
+        )
+        assert len(content["data"]["publicProjects"]["results"]) == self.MAX_LIMIT
+
+    def test_public_organizations_returns_only_active(self) -> None:
+        content = self.query_check(self.Query.PUBLIC_ORGANIZATIONS, variables={"pagination": {"limit": 10, "offset": 0}})
+        result = content["data"]["publicOrganizations"]
+        returned_ids = {r["id"] for r in result["results"]}
+        assert self.gID(self.active_organization.pk) in returned_ids
+        assert self.gID(self.archived_organization.pk) not in returned_ids
+
+    def test_public_organizations_high_limit_is_capped(self) -> None:
+        for _ in range(self.MAX_LIMIT):
+            OrganizationFactory.create(**self.user_resource_kwargs)
+        content = self.query_check(
+            self.Query.PUBLIC_ORGANIZATIONS,
+            variables={"pagination": {"limit": self.MAX_LIMIT + 10, "offset": 0}},
+        )
+        assert len(content["data"]["publicOrganizations"]["results"]) == self.MAX_LIMIT
+
+    def test_public_projects_no_pagination_uses_default(self) -> None:
+        content = self.query_check(self.Query.PUBLIC_PROJECTS)
+        result = content["data"]["publicProjects"]
+        assert result["pageInfo"]["limit"] == self.MAX_LIMIT
+
+    def test_public_organizations_no_pagination_uses_default(self) -> None:
+        content = self.query_check(self.Query.PUBLIC_ORGANIZATIONS)
+        result = content["data"]["publicOrganizations"]
+        assert result["pageInfo"]["limit"] == self.MAX_LIMIT

--- a/apps/project/tests/query_test.py
+++ b/apps/project/tests/query_test.py
@@ -1,10 +1,11 @@
 import typing
 
-from django.conf import settings
+from django.test import override_settings
 
 from apps.project.factories import OrganizationFactory, ProjectFactory
 from apps.project.models import Project, ProjectStatusEnum, ProjectTypeEnum
 from apps.user.factories import UserFactory
+from main.settings import STRAWBERRY_DJANGO
 from main.tests import TestCase
 from utils.common import format_object_keys, to_camel_case
 
@@ -353,6 +354,15 @@ class TestProjectQuery(TestCase):
             assert generated_name == generated_name_from_query, f"Name mismatch for project {project.pk}"
 
 
+MAX_LIMIT = 10
+
+
+@override_settings(
+    STRAWBERRY_DJANGO={
+        **STRAWBERRY_DJANGO,
+        "PUBLIC_PAGINATION_MAX_LIMIT": MAX_LIMIT,
+    },
+)
 class TestPublicQueriesQuery(TestCase):
     class Query:
         PUBLIC_PROJECTS = """
@@ -383,8 +393,6 @@ class TestPublicQueriesQuery(TestCase):
               }
             }
         """
-
-    MAX_LIMIT: int = settings.STRAWBERRY_DJANGO["PUBLIC_PAGINATION_MAX_LIMIT"]
 
     @typing.override
     @classmethod
@@ -436,7 +444,7 @@ class TestPublicQueriesQuery(TestCase):
         assert self.gID(self.draft_project.pk) not in returned_ids
 
     def test_public_projects_high_limit_is_capped(self) -> None:
-        for _ in range(self.MAX_LIMIT):
+        for _ in range(MAX_LIMIT):
             ProjectFactory.create(
                 **self.user_resource_kwargs,
                 requesting_organization=self.active_organization,
@@ -445,9 +453,9 @@ class TestPublicQueriesQuery(TestCase):
             )
         content = self.query_check(
             self.Query.PUBLIC_PROJECTS,
-            variables={"pagination": {"limit": self.MAX_LIMIT + 10, "offset": 0}},
+            variables={"pagination": {"limit": MAX_LIMIT + 10, "offset": 0}},
         )
-        assert len(content["data"]["publicProjects"]["results"]) == self.MAX_LIMIT
+        assert len(content["data"]["publicProjects"]["results"]) == MAX_LIMIT
 
     def test_public_organizations_returns_only_active(self) -> None:
         content = self.query_check(self.Query.PUBLIC_ORGANIZATIONS, variables={"pagination": {"limit": 10, "offset": 0}})
@@ -457,20 +465,20 @@ class TestPublicQueriesQuery(TestCase):
         assert self.gID(self.archived_organization.pk) not in returned_ids
 
     def test_public_organizations_high_limit_is_capped(self) -> None:
-        for _ in range(self.MAX_LIMIT):
+        for _ in range(MAX_LIMIT):
             OrganizationFactory.create(**self.user_resource_kwargs)
         content = self.query_check(
             self.Query.PUBLIC_ORGANIZATIONS,
-            variables={"pagination": {"limit": self.MAX_LIMIT + 10, "offset": 0}},
+            variables={"pagination": {"limit": MAX_LIMIT + 10, "offset": 0}},
         )
-        assert len(content["data"]["publicOrganizations"]["results"]) == self.MAX_LIMIT
+        assert len(content["data"]["publicOrganizations"]["results"]) == MAX_LIMIT
 
     def test_public_projects_no_pagination_uses_default(self) -> None:
         content = self.query_check(self.Query.PUBLIC_PROJECTS)
         result = content["data"]["publicProjects"]
-        assert result["pageInfo"]["limit"] == self.MAX_LIMIT
+        assert result["pageInfo"]["limit"] == MAX_LIMIT
 
     def test_public_organizations_no_pagination_uses_default(self) -> None:
         content = self.query_check(self.Query.PUBLIC_ORGANIZATIONS)
         result = content["data"]["publicOrganizations"]
-        assert result["pageInfo"]["limit"] == self.MAX_LIMIT
+        assert result["pageInfo"]["limit"] == MAX_LIMIT

--- a/main/settings.py
+++ b/main/settings.py
@@ -550,6 +550,8 @@ STRAWBERRY_DJANGO = {
     "TYPE_DESCRIPTION_FROM_MODEL_DOCSTRING": True,
     "MUTATIONS_DEFAULT_HANDLE_ERRORS": True,
     "PAGINATION_DEFAULT_LIMIT": 20,
+    # NOTE: Using for public queries, we will enforce max limit in pagination class
+    "PUBLIC_PAGINATION_MAX_LIMIT": 100,
     "DEFAULT_PK_FIELD_NAME": "id",
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1191,6 +1191,16 @@ type OrganizationTypeOffsetPaginated {
   totalCount: Int!
 }
 
+type OrganizationTypePublicOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """List of paginated results."""
+  results: [OrganizationType!]!
+
+  """Total count of existing results."""
+  totalCount: Int!
+}
+
 """Model representing the organization requesting the project."""
 input OrganizationUpdateInput {
   abbreviation: String
@@ -1978,6 +1988,16 @@ type ProjectTypeOffsetPaginated {
   totalCount: Int!
 }
 
+type ProjectTypePublicOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """List of paginated results."""
+  results: [ProjectType!]!
+
+  """Total count of existing results."""
+  totalCount: Int!
+}
+
 input ProjectTypeSpecificInput @oneOf {
   compare: CompareProjectPropertyInput
   completeness: CompletenessProjectPropertyInput
@@ -2096,9 +2116,9 @@ type Query {
   projectName(params: ProjectNameInput): String!
   projects(includeAll: Boolean! = false, filters: ProjectFilter, order: ProjectOrder, pagination: OffsetPaginationInput): ProjectTypeOffsetPaginated! @isAuthenticated
   publicOrganization(id: ID!): OrganizationType!
-  publicOrganizations(filters: OrganizationFilter, order: OrganizationOrder, pagination: OffsetPaginationInput): OrganizationTypeOffsetPaginated!
+  publicOrganizations(filters: OrganizationFilter, order: OrganizationOrder, pagination: OffsetPaginationInput): OrganizationTypePublicOffsetPaginated!
   publicProject(id: ID!): ProjectType!
-  publicProjects(filters: ProjectFilter, order: ProjectOrder, pagination: OffsetPaginationInput): ProjectTypeOffsetPaginated!
+  publicProjects(filters: ProjectFilter, order: ProjectOrder, pagination: OffsetPaginationInput): ProjectTypePublicOffsetPaginated!
   testAoiObjects(projectId: ID!, assetId: ID!, ohsomeFilter: String!): TestValidateAoiObjectsResponse! @isAuthenticated
   testTaskingManagerProject(hotTmId: String!, ohsomeFilter: String!): TestValidateTaskingManagerProjectResponse! @isAuthenticated
   tileServers: RasterTileServersType! @isAuthenticated

--- a/utils/graphql/pagination.py
+++ b/utils/graphql/pagination.py
@@ -1,0 +1,35 @@
+import typing
+from typing import Any, Self
+
+import strawberry
+from django.conf import settings
+from django.db.models import QuerySet
+from strawberry.types import Info
+from strawberry.types.unset import UNSET
+from strawberry_django.pagination import NodeType, OffsetPaginated, OffsetPaginationInput
+
+
+@strawberry.type
+class PublicOffsetPaginated(OffsetPaginated[NodeType]):
+    """OffsetPaginated subclass that enforces PUBLIC_PAGINATION_MAX_LIMIT."""
+
+    @typing.override
+    @classmethod
+    def resolve_paginated(
+        cls,
+        queryset: QuerySet,
+        *,
+        info: Info,
+        pagination: OffsetPaginationInput | None = None,
+        **kwargs: Any,
+    ) -> Self:
+        max_limit: int | None = getattr(settings, "STRAWBERRY_DJANGO", {}).get("PUBLIC_PAGINATION_MAX_LIMIT")
+        assert max_limit is not None, "STRAWBERRY_DJANGO.PUBLIC_PAGINATION_MAX_LIMIT must be set in settings"
+
+        if pagination is None:
+            pagination = OffsetPaginationInput(offset=0, limit=max_limit)
+        else:
+            limit = pagination.limit
+            if limit is UNSET or limit is None or limit < 0 or limit > max_limit:
+                pagination = OffsetPaginationInput(offset=pagination.offset, limit=max_limit)
+        return super().resolve_paginated(queryset, info=info, pagination=pagination, **kwargs)


### PR DESCRIPTION
## Changes
- Adding a wrapper PublicOffsetPaginated for the pagination limit changes. 
- set 100 as defaullt

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
