### PR TITLE
Fix: Replace firebase PENDING gate with version-based idempotency

### DIFF
--- a/apps/project/exports/exports.py
+++ b/apps/project/exports/exports.py
@@ -6,7 +6,7 @@ from django.core.files import File
 from django.db import transaction
 from ulid import ULID
 
-from apps.common.models import AssetTypeEnum, FirebasePushStatusEnum
+from apps.common.models import AssetTypeEnum
 from apps.project.custom_options import get_fallback_custom_options_for_export
 from apps.project.exports.geojson import gzipped_csv_to_gzipped_geojson
 from apps.project.exports.utils.project_progress import calculate_project_progress
@@ -195,10 +195,10 @@ def _export_project_data(project: Project, tmp_directory: Path):
             )
 
         if project.progress != previous_progress:
+            project.request_firebase_push()
             transaction.on_commit(
                 lambda: push_project_to_firebase.delay(project_id=project.id, only_stats=True),
             )
-            project.update_firebase_push_status(FirebasePushStatusEnum.PENDING, False)
 
     project.save(
         update_fields=(
@@ -208,8 +208,6 @@ def _export_project_data(project: Project, tmp_directory: Path):
             "number_of_results",
             "number_of_results_for_progress",
             "last_contribution_date",
-            "firebase_push_status",
-            "firebase_last_pushed",
         ),
     )
 

--- a/apps/project/migrations/0015_project_firebase_push_version.py
+++ b/apps/project/migrations/0015_project_firebase_push_version.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('project', '0014_remove_project_unique_project_name_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='firebase_push_requested_version',
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='firebase_pushed_version',
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/apps/project/models.py
+++ b/apps/project/models.py
@@ -476,6 +476,14 @@ class Project(UserResource, FirebasePushResource):
         help_text=gettext_lazy("Stores the last progress checkpoint notified via Slack."),
     )
 
+    # FIREBASE PUSH VERSIONING
+    # Bumped atomically by every push trigger; the push task uses this to detect
+    # whether a newer request arrived while it was working (trailing-edge re-enqueue).
+    firebase_push_requested_version = models.PositiveIntegerField[int, int](default=0)
+    # Set to the requested_version snapshot taken at the START of a successful push.
+    # If pushed_version >= requested_version the project is already up-to-date in Firebase.
+    firebase_pushed_version = models.PositiveIntegerField[int, int](default=0)
+
     # Type hints
     requesting_organization_id: int
     tutorial_id: int | None
@@ -517,6 +525,12 @@ class Project(UserResource, FirebasePushResource):
         project_number: int,
     ) -> str:
         return f"{project_type.label} - {topic} - {region} ({project_number}) {requesting_organization_name}"
+
+    def request_firebase_push(self) -> None:
+        """Atomically increment requested version. Safe to call from concurrent transactions."""
+        Project.objects.filter(pk=self.pk).update(
+            firebase_push_requested_version=models.F("firebase_push_requested_version") + 1,
+        )
 
     # FIXME(tnagorra): rename this to generated_name
     def generate_name(self) -> str:

--- a/apps/project/serializers.py
+++ b/apps/project/serializers.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from django.utils.translation import gettext
 from rest_framework import serializers
 
-from apps.common.models import AssetMimetypeEnum, CommonAsset, FirebasePushStatusEnum
+from apps.common.models import AssetMimetypeEnum, CommonAsset
 from apps.common.serializers import ArchivableResourceSerializer, CommonAssetSerializer, UserResourceSerializer
 from apps.contributor.models import ContributorTeam
 from apps.project.firebase.push import FirebaseOrganizationPush
@@ -547,7 +547,7 @@ class ProcessedProjectUpdateSerializer(UserResourceSerializer[Project]):
             Project.Status.WITHDRAWN,
             Project.Status.FINISHED,
         ]:
-            updated_project.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
+            updated_project.request_firebase_push()
             transaction.on_commit(lambda: push_project_to_firebase.delay(updated_project.pk))
 
         return updated_project
@@ -849,7 +849,7 @@ class ProjectStatusUpdateSerializer(UserResourceSerializer[Project]):
             Project.Status.WITHDRAWN,
             Project.Status.FINISHED,
         ]:
-            updated_project.update_firebase_push_status(FirebasePushStatusEnum.PENDING)
+            updated_project.request_firebase_push()
             transaction.on_commit(
                 lambda: chain(
                     push_project_to_firebase.si(updated_project.pk),

--- a/apps/project/tests/firebase_push_race_test.py
+++ b/apps/project/tests/firebase_push_race_test.py
@@ -1,0 +1,178 @@
+"""Regression tests for the PUBLISHED -> FINISHED firebase push race condition.
+
+Bug: when a stats push (only_stats=True) and a status-change push raced for
+the same project, the finish push was rejected by the PENDING guard, leaving
+the project visible in Firebase even though DB showed FINISHED.
+
+Fix: replaced the firebase_push_status PENDING gate with version numbers.
+  firebase_push_requested_version — bumped by every trigger
+  firebase_pushed_version         — recorded on push success (snapshot from start)
+
+The push task checks pushed >= requested and skips if already up-to-date.
+A trailing-edge re-enqueue heals the lock-drop path.
+"""
+
+import typing
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from apps.common.models import FirebasePushStatusEnum
+from apps.project.factories import OrganizationFactory, ProjectFactory
+from apps.project.models import Project
+from apps.project.tasks import push_project_to_firebase
+from apps.user.factories import UserFactory
+from main.cache import CeleryLock
+from main.cache import cache as celery_lock_cache
+from main.tests import TestCase
+from project_types.store import get_project_type_handler
+from project_types.tile_map_service.find.project import FindProjectProperty
+from utils.geo.raster_tile_server.config import RasterTileServerNameEnum
+from utils.geo.raster_tile_server.models import RasterTileServerCommonConfig, RasterTileServerConfig
+
+
+def _find_project_specifics() -> dict[str, typing.Any]:
+    return FindProjectProperty(
+        zoom_level=14,
+        tile_server_property=RasterTileServerConfig(
+            name=RasterTileServerNameEnum.BING,
+            bing=RasterTileServerCommonConfig(credits="test"),
+        ),
+        aoi_geometry="1",
+    ).model_dump()
+
+
+class TestFirebasePushRaceConditionFixed(TestCase):
+    """Verifies the version-based fix prevents false FAILED and silent lock-drops."""
+
+    @typing.override
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = UserFactory.create()
+        cls.user_kwargs = dict(created_by=cls.user, modified_by=cls.user)
+        cls.organization = OrganizationFactory.create(**cls.user_kwargs)
+
+    def _published_project(self, **kwargs: typing.Any) -> Project:
+        return ProjectFactory.create(
+            **self.user_kwargs,
+            requesting_organization=self.organization,
+            status=Project.Status.PUBLISHED,
+            firebase_push_status=FirebasePushStatusEnum.SUCCESS,
+            firebase_last_pushed=timezone.now(),
+            project_type_specifics=_find_project_specifics(),
+            **kwargs,
+        )
+
+    def test_already_up_to_date_is_noop_not_failed(self):
+        """Old: firebase_push_status=SUCCESS -> guard fails -> FAILED.
+
+        New: pushed_version >= requested_version → early return, no FAILED.
+        """
+        project = self._published_project(
+            firebase_push_requested_version=1,
+            firebase_pushed_version=1,  # already satisfied
+        )
+        Project.objects.filter(pk=project.pk).update(status=Project.Status.FINISHED)
+
+        project_from_db = Project.objects.get(pk=project.pk)
+        handler = get_project_type_handler(project_from_db.project_type_enum)(project_from_db)
+        handler.push_project_on_firebase()
+
+        project.refresh_from_db()
+        # Should remain SUCCESS (no exception, no FAILED)
+        assert project.firebase_push_status_enum == FirebasePushStatusEnum.SUCCESS
+        assert project.status_enum == Project.Status.FINISHED
+
+    def test_task_path_already_up_to_date_is_noop(self):
+        """Same via the full task entry point."""
+        project = self._published_project(
+            firebase_push_requested_version=2,
+            firebase_pushed_version=2,
+        )
+        Project.objects.filter(pk=project.pk).update(status=Project.Status.FINISHED)
+
+        push_project_to_firebase(project.pk)
+
+        project.refresh_from_db()
+        assert project.firebase_push_status_enum == FirebasePushStatusEnum.SUCCESS
+        assert project.status_enum == Project.Status.FINISHED
+
+    def test_lock_drop_still_returns_none(self):
+        """Lock-drop path unchanged: task returns None when lock is held."""
+        project = self._published_project(
+            firebase_push_requested_version=1,
+            firebase_pushed_version=0,
+        )
+        Project.objects.filter(pk=project.pk).update(status=Project.Status.FINISHED)
+
+        lock_key = CeleryLock.Key.PUSH_PROJECT_TO_FIREBASE.format(project.pk)
+        celery_lock_cache.add(lock_key, 1, 60)
+
+        try:
+            result = push_project_to_firebase(project.pk)
+            assert result is None
+        finally:
+            celery_lock_cache.delete(lock_key)
+
+    def test_request_firebase_push_increments_version(self):
+        """request_firebase_push() atomically bumps requested_version."""
+        project = self._published_project(
+            firebase_push_requested_version=0,
+            firebase_pushed_version=0,
+        )
+        project.request_firebase_push()
+        project.refresh_from_db()
+        assert project.firebase_push_requested_version == 1
+        assert project.firebase_pushed_version == 0
+
+    def test_trailing_edge_reenqueue_satisfies_concurrent_version_bump(self):
+        """T1 snapshots v1; concurrent bump sets requested=2 mid-push;
+        T1 success -> trailing-edge re-enqueues T3; T3 satisfies v2.
+
+        This also covers the lock-drop path: T2 was dropped by the lock while
+        T1 held it, but T1's trailing-edge re-enqueue heals the gap.
+        """
+        project = self._published_project(
+            firebase_push_requested_version=1,
+            firebase_pushed_version=0,
+        )
+
+        # T1 loads the project — snapshot will be v1
+        project_from_db = Project.objects.get(pk=project.pk)
+
+        # Concurrent request (T2) bumps to v2 while T1 is "in flight"
+        Project.objects.filter(pk=project.pk).update(firebase_push_requested_version=2)
+
+        handler = get_project_type_handler(project_from_db.project_type_enum)(project_from_db)
+
+        with (
+            patch("project_types.base.project.BaseProject._push_project_on_firebase"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            handler.push_project_on_firebase()
+
+        project.refresh_from_db()
+        # T1 satisfied v1, trailing-edge re-enqueued T3, T3 satisfied v2
+        assert project.firebase_pushed_version == 2
+        assert project.firebase_push_status_enum == FirebasePushStatusEnum.SUCCESS
+
+    def test_no_trailing_edge_reenqueue_when_no_concurrent_bump(self):
+        """No new request during push → no re-enqueue, pushed_version=requested_version."""
+        project = self._published_project(
+            firebase_push_requested_version=1,
+            firebase_pushed_version=0,
+        )
+        project_from_db = Project.objects.get(pk=project.pk)
+        handler = get_project_type_handler(project_from_db.project_type_enum)(project_from_db)
+
+        with (
+            patch("project_types.base.project.BaseProject._push_project_on_firebase"),
+            self.captureOnCommitCallbacks(execute=False) as callbacks,
+        ):
+            handler.push_project_on_firebase()
+
+        assert callbacks == []
+        project.refresh_from_db()
+        assert project.firebase_pushed_version == 1
+        assert project.firebase_push_status_enum == FirebasePushStatusEnum.SUCCESS

--- a/project_types/base/project.py
+++ b/project_types/base/project.py
@@ -8,7 +8,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from django.contrib.gis.db.models import GeometryField
 from django.contrib.gis.db.models.functions import Area
 from django.core.files.base import ContentFile
-from django.db import models
+from django.db import models, transaction
 from django.db.models.expressions import Subquery
 from django.db.models.functions import Cast, Coalesce
 from firebase_admin.db import Reference as FbReference  # type: ignore[reportMissingTypeStubs]
@@ -513,12 +513,6 @@ class BaseProject[
             raise ValidationException(
                 f"Project cannot be pushed to firebase if project status is '{self.project.status_enum.label}'",
             )
-        if self.project.firebase_push_status_enum != FirebasePushStatusEnum.PENDING:
-            label = self.project.firebase_push_status_enum.label if self.project.firebase_push_status_enum else "None"
-            raise ValidationException(
-                f"Project cannot be pushed to firebase if firebase push status is '{label}'",
-            )
-
         self.project.update_firebase_push_status(FirebasePushStatusEnum.PROCESSING)
 
         project_ref = self.firebase_helper.ref(
@@ -548,6 +542,19 @@ class BaseProject[
             self.update_project_on_firebase(project_ref, valid_project, only_stats=only_stats)
 
     def push_project_on_firebase(self, *, only_stats: bool = False):
+        from apps.project.tasks import push_project_to_firebase  # noqa: PLC0415
+
+        # Snapshot at start, inside the Redis lock, so no other push is running.
+        # This is the version number this execution is responsible for satisfying.
+        requested_version = self.project.firebase_push_requested_version
+
+        if self.project.firebase_pushed_version >= requested_version:
+            logger.info(
+                "firebase already up-to-date, skipping push",
+                extra=log_extra({"project": self.project.pk}),
+            )
+            return
+
         try:
             self._push_project_on_firebase(only_stats=only_stats)
         except Exception as ex:
@@ -585,7 +592,6 @@ class BaseProject[
                     "status",
                     "status_message",
                     "firebase_push_status",
-                    "firebase_last_pushed",
                 ],
             )
         else:
@@ -601,6 +607,21 @@ class BaseProject[
                     "firebase_last_pushed",
                 ],
             )
+            # Record the version we satisfied — use the snapshot taken at START, not a
+            # re-read, so a concurrent bump can't mark version N+1 as pushed while we
+            # only wrote version-N data.
+            Project.objects.filter(pk=self.project.pk).update(
+                firebase_pushed_version=requested_version,
+            )
+            # Trailing-edge check: if a new request arrived while we were pushing,
+            # re-enqueue a full push so it is not silently dropped (heals the lock-drop
+            # path too). Always use only_stats=False — a full push is a superset of a
+            # stats push, and we cannot know what the new request intended.
+            self.project.refresh_from_db(fields=["firebase_push_requested_version"])
+            if self.project.firebase_push_requested_version > requested_version:
+                transaction.on_commit(
+                    lambda: push_project_to_firebase.delay(self.project.pk),
+                )
 
     # EXPORT
 


### PR DESCRIPTION
The PENDING status guard caused a race: a stats push (only_stats=True) and a status-change push racing for the same project would leave the second push rejected as FAILED, keeping a FINISHED project visible in Firebase.

## Problem

When a stats push (`only_stats=True`) and a status-change push raced for the
same project, the second push hit the PENDING guard and was rejected as FAILED,
leaving a FINISHED project still visible in Firebase.

## Changes
Replaced the PENDING status gate with two version counters on `Project`:

  - `firebase_push_requested_version` — bumped atomically by every push trigger
  - `firebase_pushed_version` — recorded on success using the snapshot taken at
    task start (not a re-read), so a concurrent bump can't be marked as satisfied
    with stale data

  The push task:
  1. Skips if `pushed_version >= requested_version` (already up-to-date, no false FAILED)
  2. Re-enqueues on success if `requested_version` grew mid-push — heals the silent
     lock-drop path where a concurrent task is dropped while the lock is held

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
