### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+We want to invite the vast community of developers to contribute to our mission and improve MapSwipe backend.
+
+## Contributions
+
+We welcome any contributions that help improve the application. Before you start hacking, please read through [README](README.md) and the issues on GitHub to find the best fit for your skills. If you find a task that you are comfortable working on, simply fork the repo and submit a PR (to the `develop` branch) when you are ready!
+
+If you are thinking of a change that is not trivial, we suggest you first [open an issue](https://github.com/mapswipe/mapswipe-backend/issues) to discuss your proposed changes. This may save you a lot of time, as other people may be working on similar (or conflicting) changes.
+
+Direct AI-generated contributions are not allowed. All contributions must be reviewed, tested, and fully understood by the contributor before submission, and repository owners will independently review, run, and verify all changes. Additionally, all PRs must go through a proper review process, with final review and approval conducted by Togglecorp before merging. Contributors may be asked to make revisions based on feedback.
+
+## GitHub Actions
+
+This is detailed in the CI config files under `.github/workflows`.


### PR DESCRIPTION
Adds a CONTRIBUTING.md matching the one in mapswipe/mapswipe-web, adapted for this repo's default branch and issue tracker.